### PR TITLE
Rename API Console branding and fix drawer layout

### DIFF
--- a/__tests__/router.test.js
+++ b/__tests__/router.test.js
@@ -173,7 +173,7 @@ describe('loadPageContent behavior', () => {
 
     window.RouterContentLoader = {
       fetchPageMarkup,
-      DEFAULT_PAGE_TITLE: 'D4rK API Console'
+      DEFAULT_PAGE_TITLE: 'API Console'
     };
 
     const updateTitle = jest.fn();
@@ -588,10 +588,10 @@ describe('RouterContentLoader.fetchPageMarkup', () => {
 
     expect(fetchSpy).not.toHaveBeenCalled();
     expect(result.status).toBe('success');
-    expect(result.title).toBe('D4rK API Console');
+    expect(result.title).toBe('API Console');
     expect(result.html).toBe(initialHomeHTML);
     expect(result.onReady).toBeNull();
-    expect(result.sourceTitle).toBe('D4rK API Console');
+    expect(result.sourceTitle).toBe('API Console');
   });
 
   test('returns empty content for non-home routes without a path', async () => {

--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -15,6 +15,10 @@ body {
   min-height: 100dvh;
 }
 
+body.drawer-is-open {
+  overflow: hidden;
+}
+
 button,
 input,
 select,

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -2,7 +2,7 @@
 md-top-app-bar {
   position: sticky;
   top: 0;
-  z-index: 1000;
+  z-index: 1200;
   min-height: 56px;
   height: calc(56px + var(--safe-area-inset-top));
   border-radius: 0;
@@ -47,6 +47,38 @@ md-top-app-bar .material-symbols-outlined {
 }
 
 /* --- Navigation Drawer --- */
+.navigation-drawer {
+  position: fixed;
+  inset-block: 0;
+  inset-inline-start: 0;
+  max-inline-size: var(--app-drawer-inline-size);
+  z-index: 1100;
+}
+
+.navigation-drawer::part(scrim) {
+  inset-block-start: calc(var(--safe-area-inset-top));
+}
+
+.navigation-drawer::part(container) {
+  border-top-right-radius: 24px;
+  border-bottom-right-radius: 24px;
+}
+
+.drawer-overlay {
+  position: fixed;
+  inset: 0;
+  background-color: var(--app-overlay-bg-color);
+  opacity: 0;
+  visibility: hidden;
+  transition: opacity 180ms ease;
+  z-index: 1000;
+}
+
+.drawer-overlay.open {
+  opacity: 1;
+  visibility: visible;
+}
+
 .drawer-content {
   display: flex;
   flex-direction: column;
@@ -89,6 +121,23 @@ md-top-app-bar .material-symbols-outlined {
 
 .nested-list .drawer-section {
   padding-inline: 0;
+}
+
+/* --- Buttons --- */
+md-filled-button,
+md-tonal-button {
+  gap: 0.75rem;
+  --_leading-space: 20px;
+  --_trailing-space: 20px;
+  --_with-leading-icon-leading-space: 20px;
+  --_with-leading-icon-trailing-space: 20px;
+  --_with-trailing-icon-leading-space: 20px;
+  --_with-trailing-icon-trailing-space: 20px;
+}
+
+md-filled-button md-icon[slot='icon'],
+md-tonal-button md-icon[slot='icon'] {
+  margin-inline-end: 0.25rem;
 }
 
 /* --- Inline Buttons --- */

--- a/assets/js/metadataManager.js
+++ b/assets/js/metadataManager.js
@@ -1,5 +1,5 @@
 (function (global) {
-    const DEFAULT_TITLE = 'D4rK API Console';
+    const DEFAULT_TITLE = 'API Console';
     const DEFAULT_DESCRIPTION = "Explore Mihai-Cristian Condrea's Android developer portfolio featuring Jetpack Compose apps, Material Design systems, and open-source tools.";
     const DEFAULT_KEYWORDS = [
         'Mihai Cristian Condrea',

--- a/assets/js/router.js
+++ b/assets/js/router.js
@@ -189,7 +189,7 @@ async function loadPageContent(pageId, updateHistory = true) {
                 historyHelper.updateTitle(appBarHeadline, notFoundTitle);
             } else {
                 if (appBarHeadline) appBarHeadline.textContent = notFoundTitle;
-                document.title = `${notFoundTitle} - D4rK API Console`;
+                document.title = `${notFoundTitle} - API Console`;
             }
 
             return;
@@ -261,7 +261,7 @@ async function loadPageContent(pageId, updateHistory = true) {
             }
         });
 
-        const pageTitle = loadResult.title || (routeConfig && routeConfig.title) || (contentLoader && contentLoader.DEFAULT_PAGE_TITLE) || 'D4rK API Console';
+        const pageTitle = loadResult.title || (routeConfig && routeConfig.title) || (contentLoader && contentLoader.DEFAULT_PAGE_TITLE) || 'API Console';
 
         updateMetadataForPage(routeConfig, pageTitle, normalizedPageId, loadResult.status);
 
@@ -269,7 +269,7 @@ async function loadPageContent(pageId, updateHistory = true) {
             historyHelper.updateTitle(appBarHeadline, pageTitle);
         } else {
             if (appBarHeadline) appBarHeadline.textContent = pageTitle;
-            document.title = `${pageTitle} - D4rK API Console`;
+            document.title = `${pageTitle} - API Console`;
         }
 
         if (historyHelper && typeof historyHelper.pushState === 'function') {

--- a/assets/js/router/contentLoader.js
+++ b/assets/js/router/contentLoader.js
@@ -1,5 +1,5 @@
 (function (global) {
-    const DEFAULT_PAGE_TITLE = 'D4rK API Console';
+    const DEFAULT_PAGE_TITLE = 'API Console';
 
     function createErrorHtml(message) {
         return `<div class="page-section active"><p class="error-message text-red-500">${message}</p></div>`;

--- a/assets/js/router/history.js
+++ b/assets/js/router/history.js
@@ -1,5 +1,5 @@
 (function (global) {
-    const DOCUMENT_TITLE_SUFFIX = ' - D4rK API Console';
+    const DOCUMENT_TITLE_SUFFIX = ' - API Console';
 
     function updateTitle(appBarHeadline, pageTitle) {
         if (appBarHeadline) {

--- a/assets/js/router/routes.js
+++ b/assets/js/router/routes.js
@@ -1,5 +1,5 @@
 (function (global) {
-    const DEFAULT_ROUTE_TITLE = 'D4rK API Console';
+    const DEFAULT_ROUTE_TITLE = 'API Console';
     const DEFAULT_METADATA_DESCRIPTION = 'Explore Mihai-Cristian Condrea\'s Android developer portfolio featuring Jetpack Compose apps, Material Design systems, and open-source tools.';
     const DEFAULT_METADATA_KEYWORDS = [
         'Mihai Cristian Condrea',
@@ -237,7 +237,7 @@
     const defaultRoutes = [
         {
             id: 'home',
-            title: 'D4rK API Console',
+            title: 'API Console',
             metadata: {
                 description: 'Design and manage the JSON APIs that power App Toolkit, English with Lidia, and Android Studio Tutorials using a visual builder.',
                 keywords: [
@@ -249,12 +249,12 @@
                 ],
                 canonicalSlug: '/',
                 openGraph: {
-                    title: 'D4rK API Console',
+                    title: 'API Console',
                     description: 'Visual tooling for crafting the JSON APIs behind D4rK\'s Android applications.',
                     type: 'website'
                 },
                 twitter: {
-                    title: 'D4rK API Console',
+                    title: 'API Console',
                     description: 'Visual tooling for crafting the JSON APIs behind D4rK\'s Android applications.'
                 }
             }
@@ -333,21 +333,21 @@
             path: 'pages/settings/code-of-conduct.html',
             title: 'Code of Conduct',
             metadata: {
-                description: 'Understand the collaboration guidelines that keep the D4rK API Console productive and respectful.',
+                description: 'Understand the collaboration guidelines that keep the API Console productive and respectful.',
                 keywords: [
-                    'D4rK API Console code of conduct',
+                    'API Console code of conduct',
                     'collaboration guidelines',
                     'API workspace policy'
                 ],
                 canonicalSlug: 'code-of-conduct',
                 openGraph: {
-                    title: 'Code of Conduct | D4rK API Console',
-                    description: 'Understand the collaboration guidelines that keep the D4rK API Console productive and respectful.',
+                    title: 'Code of Conduct | API Console',
+                    description: 'Understand the collaboration guidelines that keep the API Console productive and respectful.',
                     type: 'article'
                 },
                 twitter: {
-                    title: 'Code of Conduct | D4rK API Console',
-                    description: 'Understand the collaboration guidelines that keep the D4rK API Console productive and respectful.'
+                    title: 'Code of Conduct | API Console',
+                    description: 'Understand the collaboration guidelines that keep the API Console productive and respectful.'
                 }
             }
         }

--- a/assets/js/utils.js
+++ b/assets/js/utils.js
@@ -43,7 +43,7 @@ function setCopyrightYear() {
     if (copyrightElement) {
         const currentYear = new Date().getFullYear();
         const yearText = currentYear === 2025 ? '2025' : `2025-${currentYear}`;
-        copyrightElement.textContent = `Copyright © ${yearText}, D4rK API Console`;
+        copyrightElement.textContent = `Copyright © ${yearText}, API Console`;
     }
 }
 

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
       name="viewport"
       content="width=device-width, initial-scale=1.0, viewport-fit=cover"
     />
-    <title>D4rK API Console</title>
+    <title>API Console</title>
     <meta
       name="description"
       content="Design and manage the JSON APIs that power D4rK's Android apps with a visual editor built for App Toolkit, English with Lidia, and Android Studio Tutorials."
@@ -15,7 +15,7 @@
       name="keywords"
       content="D4rK API console, Android API builder, JSON editor, App Toolkit API, English with Lidia API, Android Studio Tutorials API"
     />
-    <meta property="og:title" content="D4rK API Console" />
+    <meta property="og:title" content="API Console" />
     <meta
       property="og:description"
       content="Design and manage JSON APIs visually for D4rK's Android applications, including App Toolkit, English with Lidia, and Android Studio Tutorials."
@@ -33,13 +33,13 @@
       property="og:url"
       content="https://d4rk7355608.github.io/com.d4rk.apis/"
     />
-    <meta property="og:site_name" content="D4rK API Console" />
+    <meta property="og:site_name" content="API Console" />
     <link
       rel="canonical"
       href="https://d4rk7355608.github.io/com.d4rk.apis/"
     />
     <meta name="twitter:card" content="summary_large_image" />
-    <meta name="twitter:title" content="D4rK API Console" />
+    <meta name="twitter:title" content="API Console" />
     <meta
       name="twitter:description"
       content="Visual tooling for crafting JSON APIs that power D4rK's Android experiences."
@@ -274,7 +274,7 @@
       >
         <md-icon><span class="material-symbols-outlined">menu</span></md-icon>
       </md-icon-button>
-      <span slot="headline" id="appBarHeadline">D4rK API Console</span>
+      <span slot="headline" id="appBarHeadline">API Console</span>
     </md-top-app-bar>
 
     <div class="content-wrapper" id="pageContentArea" data-drawer-inert-target>

--- a/pages/settings/code-of-conduct.html
+++ b/pages/settings/code-of-conduct.html
@@ -1,6 +1,6 @@
 <div id="codeOfConductPage" class="page-section active">
   <header class="page-header">
-    <h1>D4rK API Console code of conduct</h1>
+    <h1>API Console code of conduct</h1>
     <p>
       This workspace exists to maintain high-quality JSON APIs for D4rK's
       Android applications. Follow these guidelines to keep collaboration


### PR DESCRIPTION
## Summary
- rename the product branding to "API Console" throughout the metadata, router defaults, and page content
- adjust the navigation drawer layering, overlay, and body scrolling so the top app bar remains visible
- tune Material buttons that include icons to provide consistent icon/text spacing

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68daba2f99e0832d803f9d9ef8b47b59