### PR TITLE
Refine App Toolkit remote import UI

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -450,6 +450,62 @@ md-tonal-button md-icon[slot='icon'] {
   align-items: center;
 }
 
+.builder-remote-card {
+  margin-top: 1.5rem;
+}
+
+.builder-remote-card .card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1.25rem;
+}
+
+.builder-remote-header h2 {
+  margin: 0 0 0.25rem 0;
+  font-size: 1.1rem;
+  font-weight: 600;
+  color: var(--app-text-color);
+}
+
+.builder-remote-header p {
+  margin: 0;
+  color: var(--app-secondary-text-color);
+  font-size: 0.95rem;
+}
+
+.builder-remote-controls {
+  display: grid;
+  grid-template-columns: minmax(240px, 1fr) auto;
+  gap: 0.75rem;
+  align-items: end;
+}
+
+.builder-remote-controls md-outlined-text-field {
+  width: 100%;
+}
+
+.builder-remote-presets {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.builder-remote-presets-label {
+  font-size: 0.75rem;
+  font-weight: 700;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+  color: var(--app-secondary-text-color);
+}
+
+.builder-remote-presets md-text-button {
+  --md-text-button-container-shape: 999px;
+  --md-text-button-label-text-size: 0.85rem;
+  --md-text-button-hover-label-text-color: var(--md-sys-color-primary);
+  --md-text-button-pressed-label-text-color: var(--md-sys-color-primary);
+}
+
 .builder-layout {
   display: grid;
   grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
@@ -664,6 +720,10 @@ md-tonal-button md-icon[slot='icon'] {
 
 @media (max-width: 1024px) {
   .builder-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .builder-remote-controls {
     grid-template-columns: 1fr;
   }
 }

--- a/pages/apis/app-toolkit.html
+++ b/pages/apis/app-toolkit.html
@@ -25,6 +25,10 @@
           When you are done, export the JSON and replace the existing file in
           <code>App Toolkit/[debug|release]/en/home/api_android_apps.json</code>.
         </li>
+        <li>
+          Use <strong>Fetch existing JSON</strong> to pull the latest data from a
+          remote file before editing.
+        </li>
       </ul>
     </div>
   </md-filled-card>
@@ -60,6 +64,58 @@
         Clear workspace
       </md-text-button>
     </div>
+
+    <md-filled-card class="builder-remote-card" id="appToolkitRemoteImport">
+      <div class="card-body">
+        <div class="builder-remote-header">
+          <div>
+            <h2>Fetch existing JSON</h2>
+            <p>Pull the latest payload before you start editing entries.</p>
+          </div>
+        </div>
+        <div class="builder-remote-controls">
+          <md-outlined-text-field
+            id="appToolkitFetchInput"
+            type="url"
+            label="JSON URL"
+            placeholder="https://example.com/api_android_apps.json"
+            supporting-text="Paste a direct link to the current api_android_apps.json file"
+            spellcheck="false"
+          >
+            <md-icon slot="leading-icon"
+              ><span class="material-symbols-outlined">link</span></md-icon
+            >
+          </md-outlined-text-field>
+          <md-filled-tonal-button id="appToolkitFetchButton">
+            <md-icon slot="icon"
+              ><span class="material-symbols-outlined">cloud_download</span></md-icon
+            >
+            Fetch from URL
+          </md-filled-tonal-button>
+        </div>
+        <div class="builder-remote-presets" aria-label="Quick fetch shortcuts">
+          <span class="builder-remote-presets-label">Quick links</span>
+          <md-text-button
+            data-app-toolkit-preset="https://raw.githubusercontent.com/MihaiCristianCondrea/com.d4rk.apis/refs/heads/main/App%20Toolkit/debug/en/home/api_android_apps.json"
+            id="appToolkitDebugPreset"
+          >
+            <md-icon slot="icon"
+              ><span class="material-symbols-outlined">download</span></md-icon
+            >
+            Debug · EN
+          </md-text-button>
+          <md-text-button
+            data-app-toolkit-preset="https://raw.githubusercontent.com/MihaiCristianCondrea/com.d4rk.apis/refs/heads/main/App%20Toolkit/release/en/home/api_android_apps.json"
+            id="appToolkitReleasePreset"
+          >
+            <md-icon slot="icon"
+              ><span class="material-symbols-outlined">download</span></md-icon
+            >
+            Release · EN
+          </md-text-button>
+        </div>
+      </div>
+    </md-filled-card>
 
     <div class="builder-layout">
       <div class="builder-forms" id="appToolkitEntries" aria-live="polite"></div>


### PR DESCRIPTION
## Summary
- replace the remote fetch section with a Material card that mirrors the other builders
- use a Material outlined text field and text buttons for preset links to keep interactions consistent
- update styling and responsive behavior around the new controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dad7a57cd8832d9a544dfee6a4ef68