### PR TITLE
Add JSON preview validation and sanitization to API builders

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -556,6 +556,32 @@ md-tonal-button md-icon[slot='icon'] {
   resize: vertical;
 }
 
+.preview-validation {
+  min-height: 1.25rem;
+  display: flex;
+  align-items: center;
+  gap: 0.35rem;
+  font-size: 0.85rem;
+  color: var(--app-secondary-text-color);
+}
+
+.preview-validation[data-status='success'] {
+  color: var(--md-sys-color-primary);
+}
+
+.preview-validation[data-status='error'] {
+  color: var(--md-sys-color-error);
+}
+
+.preview-validation[data-status='warning'] {
+  color: var(--md-sys-color-on-surface-variant);
+}
+
+.preview-validation .material-symbols-outlined {
+  font-size: 1rem;
+  line-height: 1;
+}
+
 .preview-actions {
   display: flex;
   flex-wrap: wrap;

--- a/assets/js/apis/androidStudioTutorials.js
+++ b/assets/js/apis/androidStudioTutorials.js
@@ -42,6 +42,7 @@
 
         const entriesContainer = document.getElementById('androidHomeEntries');
         const previewArea = document.getElementById('androidHomePreview');
+        const validationStatus = document.getElementById('androidHomeValidation');
         const addButton = document.getElementById('androidHomeAddCard');
         const resetButton = document.getElementById('androidHomeResetButton');
         const copyButton = document.getElementById('androidHomeCopyButton');
@@ -250,17 +251,24 @@
                 const json = utils.parseJson(text);
                 const cards = Array.isArray(json?.data) ? json.data : Array.isArray(json) ? json : [];
                 if (!cards.length) {
+                    utils.setValidationStatus(validationStatus, {
+                        status: 'error',
+                        message: 'No cards found in JSON.'
+                    });
                     throw new Error('No cards found in JSON.');
                 }
+                const toStringValue = (value) => (value === undefined || value === null ? '' : String(value));
                 state.cards = cards.map((raw) => ({
-                    lesson_id: raw.lesson_id ? String(raw.lesson_id) : '',
-                    lesson_type: raw.lesson_type || '',
-                    lesson_title: raw.lesson_title || '',
-                    lesson_description: raw.lesson_description || '',
-                    thumbnail_image_url: raw.thumbnail_image_url || '',
-                    square_image_url: raw.square_image_url || '',
-                    deep_link_path: raw.deep_link_path || raw.deep_link || '',
-                    lesson_tags: Array.isArray(raw.lesson_tags) ? raw.lesson_tags.map(String) : [],
+                    lesson_id: utils.trimString(toStringValue(raw.lesson_id)),
+                    lesson_type: utils.trimString(toStringValue(raw.lesson_type)),
+                    lesson_title: utils.trimString(toStringValue(raw.lesson_title)),
+                    lesson_description: utils.trimString(toStringValue(raw.lesson_description)),
+                    thumbnail_image_url: utils.trimString(toStringValue(raw.thumbnail_image_url)),
+                    square_image_url: utils.trimString(toStringValue(raw.square_image_url)),
+                    deep_link_path: utils.trimString(toStringValue(raw.deep_link_path || raw.deep_link)),
+                    lesson_tags: Array.isArray(raw.lesson_tags)
+                        ? raw.lesson_tags.map((tag) => utils.trimString(toStringValue(tag))).filter(Boolean)
+                        : [],
                     customFields: Object.entries(raw)
                         .filter(([key]) => ![
                             'lesson_id',
@@ -273,37 +281,83 @@
                             'deep_link',
                             'lesson_tags'
                         ].includes(key))
-                        .map(([key, value]) => ({ key, value: stringifyValue(value) }))
+                        .map(([key, value]) => ({
+                            key: utils.trimString(key),
+                            value: stringifyValue(value)
+                        }))
                 }));
                 render();
             } catch (error) {
                 console.error('AndroidHome import failed', error);
+                utils.setValidationStatus(validationStatus, {
+                    status: 'error',
+                    message: error.message || 'Unable to import JSON.'
+                });
                 alert(error.message || 'Unable to import JSON.');
             }
         }
 
-        function updatePreview() {
-            const cards = state.cards
-                .map((card) => {
-                    const payload = {};
-                    if (card.lesson_id) payload.lesson_id = card.lesson_id;
-                    if (card.lesson_type) payload.lesson_type = card.lesson_type;
-                    if (card.lesson_title) payload.lesson_title = card.lesson_title;
-                    if (card.lesson_description) payload.lesson_description = card.lesson_description;
-                    if (card.thumbnail_image_url) payload.thumbnail_image_url = card.thumbnail_image_url;
-                    if (card.square_image_url) payload.square_image_url = card.square_image_url;
-                    if (card.deep_link_path) payload.deep_link_path = card.deep_link_path;
-                    const tags = card.lesson_tags.filter((tag) => tag && tag.trim());
-                    if (tags.length) payload.lesson_tags = tags;
-                    card.customFields.filter((field) => field.key).forEach((field) => {
-                        payload[field.key] = parseMaybeNumber(field.value);
-                    });
-                    return payload;
-                })
-                .filter((card) => Object.keys(card).length > 0);
-            if (previewArea) {
-                previewArea.value = utils.formatJson({ data: cards });
+        function sanitizeHomeCard(card) {
+            const trimmed = (value) =>
+                utils.trimString(
+                    typeof value === 'string' ? value : value == null ? '' : String(value)
+                );
+            const payload = {};
+            const lessonId = trimmed(card.lesson_id);
+            if (lessonId) payload.lesson_id = lessonId;
+            const lessonType = trimmed(card.lesson_type);
+            if (lessonType) payload.lesson_type = lessonType;
+            const lessonTitle = trimmed(card.lesson_title);
+            if (lessonTitle) payload.lesson_title = lessonTitle;
+            const description = trimmed(card.lesson_description);
+            if (description) payload.lesson_description = description;
+            const thumbnail = trimmed(card.thumbnail_image_url);
+            if (thumbnail) payload.thumbnail_image_url = thumbnail;
+            const square = trimmed(card.square_image_url);
+            if (square) payload.square_image_url = square;
+            const deepLink = trimmed(card.deep_link_path);
+            if (deepLink) payload.deep_link_path = deepLink;
+            const tags = (Array.isArray(card.lesson_tags) ? card.lesson_tags : [])
+                .map((tag) => trimmed(tag))
+                .filter(Boolean);
+            if (tags.length) {
+                payload.lesson_tags = Array.from(new Set(tags));
             }
+            card.customFields
+                .map((field) => ({ key: trimmed(field.key), value: field.value }))
+                .filter((field) => field.key)
+                .forEach((field) => {
+                    const parsed = parseMaybeNumber(field.value);
+                    if (parsed !== '') {
+                        payload[field.key] = parsed;
+                    }
+                });
+            return payload;
+        }
+
+        function updatePreview() {
+            utils.renderJsonPreview({
+                previewArea,
+                statusElement: validationStatus,
+                data: state.cards,
+                buildPayload: (cards) => ({ data: cards }),
+                autoFix: (payload) => {
+                    const cards = Array.isArray(payload?.data) ? payload.data : [];
+                    payload.data = cards
+                        .map((card) => sanitizeHomeCard(card))
+                        .filter((card) => Object.keys(card).length > 0);
+                    return payload;
+                },
+                successMessage: (payload) => {
+                    const count = Array.isArray(payload?.data) ? payload.data.length : 0;
+                    if (!count) {
+                        return 'Valid JSON · No cards yet';
+                    }
+                    return count === 1
+                        ? 'Valid JSON · 1 home card'
+                        : `Valid JSON · ${count} home cards`;
+                }
+            });
         }
 
         attachCommonHandlers({
@@ -341,6 +395,7 @@
         const metadataContainer = document.getElementById('androidLessonMetadata');
         const blocksContainer = document.getElementById('androidLessonBlocks');
         const previewArea = document.getElementById('androidLessonPreview');
+        const validationStatus = document.getElementById('androidLessonValidation');
         const titleField = document.getElementById('androidLessonTitle');
         const addBlockButton = document.getElementById('androidLessonAddBlock');
         const resetButton = document.getElementById('androidLessonResetButton');
@@ -540,19 +595,30 @@
                 const json = utils.parseJson(text);
                 const lessons = Array.isArray(json?.data) ? json.data : [];
                 if (!lessons.length) {
+                    utils.setValidationStatus(validationStatus, {
+                        status: 'error',
+                        message: 'No lessons found.'
+                    });
                     throw new Error('No lessons found.');
                 }
                 const lesson = lessons[0];
-                state.title = lesson.lesson_title || '';
+                state.title = utils.trimString(lesson.lesson_title || '');
                 if (titleField) titleField.value = state.title;
                 state.metadata = Object.entries(lesson)
                     .filter(([key]) => !['lesson_title', 'lesson_content'].includes(key))
-                    .map(([key, value]) => ({ key, value: stringifyValue(value) }));
+                    .map(([key, value]) => ({
+                        key: utils.trimString(key),
+                        value: stringifyValue(value)
+                    }));
                 const content = Array.isArray(lesson.lesson_content) ? lesson.lesson_content : [];
                 state.blocks = content.map((entry, index) => mapBlockFromJson(entry, index));
                 render();
             } catch (error) {
                 console.error('AndroidLesson import failed', error);
+                utils.setValidationStatus(validationStatus, {
+                    status: 'error',
+                    message: error.message || 'Unable to import lesson JSON.'
+                });
                 alert(error.message || 'Unable to import lesson JSON.');
             }
         }
@@ -572,20 +638,30 @@
                 if (allowed.has(key)) {
                     block.props[key] = stringifyValue(value);
                 } else {
-                    block.customFields.push({ key, value: stringifyValue(value) });
+                    block.customFields.push({
+                        key: utils.trimString(key),
+                        value: stringifyValue(value)
+                    });
                 }
             });
             return block;
         }
 
-        function updatePreview() {
+        function composeLessonPayload() {
             const lesson = {};
-            if (state.title) {
-                lesson.lesson_title = state.title;
+            const title = utils.trimString(state.title ?? '');
+            if (title) {
+                lesson.lesson_title = title;
             }
-            state.metadata.filter((field) => field.key).forEach((field) => {
-                lesson[field.key] = parseMaybeNumber(field.value);
-            });
+            state.metadata
+                .map((field) => ({ key: utils.trimString(field.key), value: field.value }))
+                .filter((field) => field.key)
+                .forEach((field) => {
+                    const parsed = parseMaybeNumber(field.value);
+                    if (parsed !== '') {
+                        lesson[field.key] = parsed;
+                    }
+                });
             const content = state.blocks
                 .map((block) => buildBlockPayload(block))
                 .filter((payload) => Object.keys(payload).length > 0);
@@ -593,15 +669,40 @@
                 lesson.lesson_content = content;
             }
             const finalData = Object.keys(lesson).length ? [lesson] : [];
-            if (previewArea) {
-                previewArea.value = utils.formatJson({ data: finalData });
-            }
+            return { data: finalData };
+        }
+
+        function updatePreview() {
+            utils.renderJsonPreview({
+                previewArea,
+                statusElement: validationStatus,
+                data: null,
+                buildPayload: composeLessonPayload,
+                successMessage: (payload) => {
+                    const lessons = Array.isArray(payload?.data) ? payload.data : [];
+                    const firstLesson = lessons[0];
+                    if (!firstLesson || Object.keys(firstLesson).length === 0) {
+                        return 'Valid JSON · No lesson data yet';
+                    }
+                    const blocks = Array.isArray(firstLesson.lesson_content)
+                        ? firstLesson.lesson_content.length
+                        : 0;
+                    if (!blocks) {
+                        return 'Valid JSON · Lesson metadata only';
+                    }
+                    return blocks === 1
+                        ? 'Valid JSON · 1 content block'
+                        : `Valid JSON · ${blocks} content blocks`;
+                }
+            });
         }
 
         function buildBlockPayload(block) {
             const payload = {};
-            if (block.content_id) payload.content_id = block.content_id;
-            if (block.content_type) payload.content_type = block.content_type;
+            const contentId = utils.trimString(block.content_id ?? '');
+            if (contentId) payload.content_id = contentId;
+            const contentType = utils.trimString(block.content_type ?? '');
+            if (contentType) payload.content_type = contentType;
             const definitions = ANDROID_BLOCK_FIELDS[block.content_type] || [];
             definitions.forEach((definition) => {
                 const value = block.props[definition.key];
@@ -614,13 +715,20 @@
                         payload[definition.key] = parsed;
                     }
                 } else {
-                    payload[definition.key] = value;
+                    const trimmed = utils.trimString(value);
+                    if (trimmed) {
+                        payload[definition.key] = trimmed;
+                    }
                 }
             });
             block.customFields
+                .map((field) => ({ key: utils.trimString(field.key), value: field.value }))
                 .filter((field) => field.key)
                 .forEach((field) => {
-                    payload[field.key] = parseMaybeNumber(field.value);
+                    const parsed = parseMaybeNumber(field.value);
+                    if (parsed !== '') {
+                        payload[field.key] = parsed;
+                    }
                 });
             return payload;
         }

--- a/pages/apis/android-studio-tutorials.html
+++ b/pages/apis/android-studio-tutorials.html
@@ -99,6 +99,12 @@
                 spellcheck="false"
                 aria-label="Android Studio Tutorials home JSON preview"
               ></textarea>
+              <div
+                class="preview-validation"
+                id="androidHomeValidation"
+                role="status"
+                aria-live="polite"
+              ></div>
               <div class="preview-actions">
                 <md-filled-tonal-button id="androidHomeCopyButton">
                   <md-icon slot="icon"
@@ -206,6 +212,12 @@
                 spellcheck="false"
                 aria-label="Android Studio Tutorials lesson JSON preview"
               ></textarea>
+              <div
+                class="preview-validation"
+                id="androidLessonValidation"
+                role="status"
+                aria-live="polite"
+              ></div>
               <div class="preview-actions">
                 <md-filled-tonal-button id="androidLessonCopyButton">
                   <md-icon slot="icon"

--- a/pages/apis/app-toolkit.html
+++ b/pages/apis/app-toolkit.html
@@ -131,6 +131,12 @@
           spellcheck="false"
           aria-label="App Toolkit JSON preview"
         ></textarea>
+        <div
+          class="preview-validation"
+          id="appToolkitValidation"
+          role="status"
+          aria-live="polite"
+        ></div>
         <div class="preview-actions">
           <md-filled-tonal-button id="appToolkitCopyButton">
             <md-icon slot="icon"

--- a/pages/apis/english-with-lidia.html
+++ b/pages/apis/english-with-lidia.html
@@ -99,6 +99,12 @@
                 spellcheck="false"
                 aria-label="English with Lidia home JSON preview"
               ></textarea>
+              <div
+                class="preview-validation"
+                id="englishHomeValidation"
+                role="status"
+                aria-live="polite"
+              ></div>
               <div class="preview-actions">
                 <md-filled-tonal-button id="englishHomeCopyButton">
                   <md-icon slot="icon"
@@ -207,6 +213,12 @@
                 spellcheck="false"
                 aria-label="English with Lidia lesson JSON preview"
               ></textarea>
+              <div
+                class="preview-validation"
+                id="englishLessonValidation"
+                role="status"
+                aria-live="polite"
+              ></div>
               <div class="preview-actions">
                 <md-filled-tonal-button id="englishLessonCopyButton">
                   <md-icon slot="icon"


### PR DESCRIPTION
## Summary
- add shared preview renderer in ApiBuilderUtils for validation, formatting, and status messaging
- sanitize App Toolkit, English with Lidia, and Android Studio Tutorials builders and surface JSON validation feedback
- add preview validation UI elements and styles across the API builder pages

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc082789c832db8214dee25c94c15