### PR TITLE
Add GitHub publishing flow to App Toolkit API workspace

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -506,6 +506,22 @@ md-tonal-button md-icon[slot='icon'] {
   --md-text-button-pressed-label-text-color: var(--md-sys-color-primary);
 }
 
+.builder-github-fields {
+  display: grid;
+  gap: 0.75rem;
+}
+
+.builder-github-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  align-items: center;
+}
+
+.builder-github-actions .preview-validation {
+  min-height: 2.5rem;
+}
+
 .builder-layout {
   display: grid;
   grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);

--- a/pages/apis/app-toolkit.html
+++ b/pages/apis/app-toolkit.html
@@ -117,6 +117,90 @@
       </div>
     </md-filled-card>
 
+    <md-filled-card class="builder-remote-card" id="appToolkitGithubCard">
+      <div class="card-body">
+        <div class="builder-remote-header">
+          <div>
+            <h2>Publish to GitHub</h2>
+            <p>
+              Use the GitHub Contents API to update the catalog once the JSON
+              preview is valid. Tokens are used only for this request and never
+              stored.
+            </p>
+          </div>
+        </div>
+        <div class="builder-github-fields">
+          <label class="api-field" for="appToolkitGithubToken">
+            <span class="api-field-label">Personal access token</span>
+            <input
+              id="appToolkitGithubToken"
+              class="api-input"
+              type="password"
+              autocomplete="off"
+              spellcheck="false"
+              placeholder="ghp_..."
+              aria-describedby="appToolkitGithubTokenHelp"
+            />
+            <span class="api-field-helper" id="appToolkitGithubTokenHelp"
+              >Requires the <code>repo</code> scope.</span
+            >
+          </label>
+          <label class="api-field" for="appToolkitGithubRepo">
+            <span class="api-field-label">Repository (owner/name)</span>
+            <input
+              id="appToolkitGithubRepo"
+              class="api-input"
+              type="text"
+              value="MihaiCristianCondrea/com.d4rk.apis"
+              spellcheck="false"
+            />
+          </label>
+          <label class="api-field" for="appToolkitGithubBranch">
+            <span class="api-field-label">Branch</span>
+            <input
+              id="appToolkitGithubBranch"
+              class="api-input"
+              type="text"
+              value="main"
+              spellcheck="false"
+            />
+          </label>
+          <label class="api-field" for="appToolkitGithubMessage">
+            <span class="api-field-label">Commit message</span>
+            <input
+              id="appToolkitGithubMessage"
+              class="api-input"
+              type="text"
+              value="chore(app-toolkit): update catalog"
+              spellcheck="false"
+            />
+          </label>
+          <label class="api-field" for="appToolkitGithubChannel">
+            <span class="api-field-label">Target channel</span>
+            <select id="appToolkitGithubChannel" class="api-select">
+              <option value="debug">Debug</option>
+              <option value="release">Release</option>
+              <option value="both">Debug &amp; Release</option>
+            </select>
+          </label>
+        </div>
+        <div class="builder-github-actions">
+          <md-filled-button id="appToolkitGithubSubmit">
+            <md-icon slot="icon"
+              ><span class="material-symbols-outlined">cloud_upload</span></md-icon
+            >
+            Publish JSON
+          </md-filled-button>
+          <div
+            class="preview-validation"
+            id="appToolkitGithubStatus"
+            role="status"
+            aria-live="polite"
+          ></div>
+        </div>
+      </div>
+    </md-filled-card>
+
     <div class="builder-layout">
       <div class="builder-forms" id="appToolkitEntries" aria-live="polite"></div>
       <aside class="builder-preview" aria-label="JSON preview">


### PR DESCRIPTION
## Summary
- add a GitHub publish card to the App Toolkit API workspace so validated JSON can be shipped directly from the UI
- integrate with the GitHub Contents API to update debug, release, or both payloads with commit message, branch, and repository controls
- style the new controls so the GitHub workflow matches the existing builder layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcc429a8cc832d94c9cdbcc80f746d