### PR TITLE
Fix tonal fetch button icon spacing

### DIFF
--- a/assets/css/base.css
+++ b/assets/css/base.css
@@ -50,6 +50,20 @@ optgroup {
   display: block;
 }
 
+.app-footer {
+  margin-top: auto;
+  padding: 1.5rem 1rem;
+  padding-bottom: calc(1.5rem + var(--safe-area-max-inset-bottom));
+  padding-inline-start: calc(1rem + var(--safe-area-inset-left));
+  padding-inline-end: calc(1rem + var(--safe-area-inset-right));
+  color: var(--app-footer-text-color);
+  font-size: 0.875rem;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  text-align: center;
+}
+
 .page-section-title {
   font-size: 1.75rem;
   font-weight: 500;

--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -322,12 +322,24 @@ md-filled-button,
 md-tonal-button,
 md-filled-tonal-button {
   gap: 0.5rem;
-  --_leading-space: 20px;
-  --_trailing-space: 20px;
-  --_with-leading-icon-leading-space: 16px;
-  --_with-leading-icon-trailing-space: 20px;
-  --_with-trailing-icon-leading-space: 20px;
-  --_with-trailing-icon-trailing-space: 16px;
+}
+
+md-filled-button {
+  --md-filled-button-leading-space: 20px;
+  --md-filled-button-trailing-space: 20px;
+  --md-filled-button-with-leading-icon-leading-space: 16px;
+  --md-filled-button-with-leading-icon-trailing-space: 20px;
+  --md-filled-button-with-trailing-icon-leading-space: 20px;
+  --md-filled-button-with-trailing-icon-trailing-space: 16px;
+}
+
+md-filled-tonal-button {
+  --md-filled-tonal-button-leading-space: 20px;
+  --md-filled-tonal-button-trailing-space: 20px;
+  --md-filled-tonal-button-with-leading-icon-leading-space: 16px;
+  --md-filled-tonal-button-with-leading-icon-trailing-space: 20px;
+  --md-filled-tonal-button-with-trailing-icon-leading-space: 20px;
+  --md-filled-tonal-button-with-trailing-icon-trailing-space: 16px;
 }
 
 md-outlined-button {


### PR DESCRIPTION
## Summary
- ensure filled tonal buttons receive the same icon and padding tokens as other buttons
- update shared button styles so the API builder fetch button aligns with the rest of the toolbar

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68dcd1cc72a0832d877a5672c3b2c7ec