### PR TITLE
feat: allow loading GitHub token from file in app toolkit

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -686,6 +686,13 @@ md-filled-tonal-button md-icon[slot='icon'] {
   gap: 0.4rem;
 }
 
+.api-field-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
 .api-field-label {
   font-size: 0.85rem;
   font-weight: 600;

--- a/pages/apis/app-toolkit.html
+++ b/pages/apis/app-toolkit.html
@@ -142,9 +142,27 @@
               aria-describedby="appToolkitGithubTokenHelp"
             />
             <span class="api-field-helper" id="appToolkitGithubTokenHelp"
-              >Requires the <code>repo</code> scope.</span
+              >Requires the <code>repo</code> scope. Paste the token or load it
+              from a text file.</span
             >
           </label>
+          <div class="api-field-actions">
+            <input
+              type="file"
+              id="appToolkitGithubTokenFile"
+              accept="text/plain,.txt,.token"
+              hidden
+            />
+            <md-outlined-button
+              type="button"
+              id="appToolkitGithubTokenFileButton"
+            >
+              <md-icon slot="icon"
+                ><span class="material-symbols-outlined">description</span></md-icon
+              >
+              Load token from file
+            </md-outlined-button>
+          </div>
           <label class="api-field" for="appToolkitGithubRepo">
             <span class="api-field-label">Repository (owner/name)</span>
             <input


### PR DESCRIPTION
## Summary
- add a UI control to load the GitHub token from a local text file and update the helper guidance
- validate the token when loading from a file and before publishing to GitHub
- style the new inline action so the file loader aligns with existing form controls

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68dcd48c44e4832da3805453fd84d443