### PR TITLE
Document GitHub PAT requirements in App Toolkit UI

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -474,6 +474,29 @@ md-filled-tonal-button md-icon[slot='icon'] {
   gap: 1.25rem;
 }
 
+.builder-github-note {
+  display: grid;
+  gap: 0.5rem;
+  padding: 0.85rem 1rem;
+  border-radius: 12px;
+  border: 1px solid var(--app-border-color);
+  background-color: var(--md-sys-color-surface-container-high);
+  color: var(--app-secondary-text-color);
+  font-size: 0.85rem;
+  line-height: 1.55;
+}
+
+.builder-github-note ul {
+  margin: 0;
+  padding-inline-start: 1.1rem;
+  display: grid;
+  gap: 0.35rem;
+}
+
+.builder-github-note li {
+  margin: 0;
+}
+
 .builder-remote-header h2 {
   margin: 0 0 0.25rem 0;
   font-size: 1.1rem;
@@ -491,7 +514,7 @@ md-filled-tonal-button md-icon[slot='icon'] {
   display: grid;
   grid-template-columns: minmax(240px, 1fr) auto;
   gap: 0.75rem;
-  align-items: end;
+  align-items: center;
 }
 
 .builder-remote-controls md-outlined-text-field {

--- a/pages/apis/app-toolkit.html
+++ b/pages/apis/app-toolkit.html
@@ -129,6 +129,27 @@
             </p>
           </div>
         </div>
+        <div class="builder-github-note" role="note">
+          <p>
+            <strong>Create a personal access token</strong> from
+            <em>GitHub → Settings → Developer settings → Personal access tokens</em>.
+            Choose a fine-grained token when possible and limit it to the
+            repository you are publishing.
+          </p>
+          <ul>
+            <li>
+              Fine-grained tokens: enable
+              <strong>Repository permissions → Contents: Read &amp; write</strong>
+              (Metadata is added automatically).
+            </li>
+            <li>
+              Classic tokens: select only
+              <code>public_repo</code> for public catalogs or
+              <code>repo</code> for private catalogs.
+            </li>
+            <li>Copy the token once and keep it outside of source control.</li>
+          </ul>
+        </div>
         <div class="builder-github-fields">
           <label class="api-field" for="appToolkitGithubToken">
             <span class="api-field-label">Personal access token</span>
@@ -142,8 +163,10 @@
               aria-describedby="appToolkitGithubTokenHelp"
             />
             <span class="api-field-helper" id="appToolkitGithubTokenHelp"
-              >Requires the <code>repo</code> scope. Paste the token or load it
-              from a text file.</span
+              >Use
+              <strong>Contents: Read &amp; write</strong> on fine-grained tokens or
+              the minimal <code>public_repo</code>/<code>repo</code> scope on
+              classic tokens. Paste the token or load it from a text file.</span
             >
           </label>
           <div class="api-field-actions">


### PR DESCRIPTION
## Summary
- center-align the Fetch from URL button with the URL field on the App Toolkit workspace
- add GitHub publishing guidance that explains where to create a personal access token and the minimal scopes required
- style the GitHub workflow note so it matches the existing builder layout

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dcda5156e4832db2acbc865a7a37ee