### PR TITLE
feat: refresh App Toolkit workspace interactions

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -482,6 +482,17 @@ md-filled-tonal-button md-icon[slot='icon'] {
   align-content: center;
 }
 
+#appToolkitNotesButton .note-indicator {
+  margin-left: 0.25rem;
+  color: var(--md-sys-color-primary);
+  opacity: 0;
+  transition: opacity 140ms ease;
+}
+
+#appToolkitNotesButton[data-note-state='saved'] .note-indicator {
+  opacity: 1;
+}
+
 .toolbar-status {
   display: flex;
   align-items: baseline;
@@ -505,13 +516,6 @@ md-filled-tonal-button md-icon[slot='icon'] {
   color: var(--app-text-color);
 }
 
-.toolbar-pills {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 0.45rem;
-}
-
 .toolbar-label {
   font-size: 0.8rem;
   font-weight: 600;
@@ -520,33 +524,32 @@ md-filled-tonal-button md-icon[slot='icon'] {
   color: var(--app-secondary-text-color);
 }
 
-.toolbar-pill {
-  border: none;
-  background: var(--md-sys-color-surface);
-  color: var(--app-secondary-text-color);
-  padding: 0.45rem 0.85rem;
-  border-radius: 999px;
-  font: inherit;
-  font-size: 0.85rem;
-  cursor: pointer;
-  transition: background-color 140ms ease, color 140ms ease, box-shadow 140ms ease;
-  box-shadow: inset 0 0 0 1px rgba(0, 0, 0, 0.08);
+.toolbar-segment,
+.toolbar-filters {
+  display: grid;
+  gap: 0.35rem;
+  align-content: start;
 }
 
-.toolbar-pill.active,
-.toolbar-pill:focus-visible {
-  background: linear-gradient(90deg, rgba(88, 101, 242, 0.18), rgba(24, 176, 116, 0.18));
-  color: var(--app-text-color);
-  box-shadow: inset 0 0 0 1px rgba(88, 101, 242, 0.3);
+.toolbar-segment md-segmented-button-set,
+.toolbar-filters md-filter-chip-set {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.35rem;
 }
 
-.toolbar-pill:focus-visible {
-  outline: none;
+.toolbar-segment md-segmented-button-set {
+  --md-segmented-button-container-shape: 999px;
+  --md-segmented-button-container-height: 36px;
 }
 
-.toolbar-pill:hover {
-  background: rgba(88, 101, 242, 0.16);
-  color: var(--app-text-color);
+.toolbar-filters md-filter-chip-set {
+  --md-filter-chip-container-shape: 999px;
+  --md-filter-chip-label-text-size: 0.82rem;
+}
+
+.toolbar-filters md-filter-chip[selected] {
+  --md-filter-chip-label-text-color: var(--md-sys-color-primary);
 }
 
 @media (max-width: 960px) {
@@ -559,6 +562,15 @@ md-filled-tonal-button md-icon[slot='icon'] {
   }
   .toolbar-status {
     justify-content: space-between;
+  }
+}
+
+@media (max-width: 1200px) {
+  .builder-layout {
+    grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr);
+  }
+  .builder-diff-sheet {
+    display: none;
   }
 }
 
@@ -641,25 +653,51 @@ md-filled-tonal-button md-icon[slot='icon'] {
   --md-text-button-pressed-label-text-color: var(--md-sys-color-primary);
 }
 
-.builder-github-fields {
+.builder-github-launch {
   display: grid;
-  gap: 0.75rem;
+  gap: 0.5rem;
+  align-content: start;
 }
 
-.builder-github-actions {
+.builder-github-helper {
+  margin: 0;
+  font-size: 0.85rem;
+  color: var(--app-secondary-text-color);
+}
+
+.github-dialog {
+  --md-dialog-container-shape: 28px;
+  max-width: 720px;
+}
+
+.github-dialog-content {
+  display: grid;
+  gap: 1.25rem;
+}
+
+.github-step {
+  display: grid;
+  gap: 1rem;
+}
+
+.github-step[hidden] {
+  display: none;
+}
+
+.github-step-actions {
   display: flex;
   flex-wrap: wrap;
   gap: 0.75rem;
   align-items: center;
 }
 
-.builder-github-actions .preview-validation {
+.github-status {
   min-height: 2.5rem;
 }
 
 .builder-layout {
   display: grid;
-  grid-template-columns: minmax(0, 2fr) minmax(260px, 1fr);
+  grid-template-columns: minmax(0, 2fr) minmax(280px, 1fr) minmax(240px, 0.9fr);
   gap: 1.5rem;
   align-items: start;
 }
@@ -681,6 +719,10 @@ md-filled-tonal-button md-icon[slot='icon'] {
   position: static;
 }
 
+.api-builder[data-layout='compact'] .builder-diff-sheet {
+  display: none;
+}
+
 .builder-forms {
   display: flex;
   flex-direction: column;
@@ -695,6 +737,51 @@ md-filled-tonal-button md-icon[slot='icon'] {
   flex-direction: column;
   gap: 1rem;
   box-shadow: 0 12px 32px rgba(15, 20, 25, 0.12);
+}
+
+.builder-diff-sheet {
+  --md-side-sheet-container-shape: 20px;
+  position: sticky;
+  top: 1rem;
+  align-self: stretch;
+  max-height: calc(100vh - 6rem);
+  overflow: hidden;
+  box-shadow: 0 12px 32px rgba(15, 20, 25, 0.12);
+}
+
+.diff-sheet-content {
+  max-height: inherit;
+  overflow: auto;
+}
+
+.diff-sheet-content pre {
+  margin: 0;
+  font-family: 'Fira Code', 'Source Code Pro', monospace;
+  font-size: 0.82rem;
+  line-height: 1.45;
+  white-space: pre-wrap;
+}
+
+.screenshot-dialog-content {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+.screenshot-dialog-content img {
+  max-width: min(80vw, 520px);
+  max-height: 60vh;
+  border-radius: 18px;
+  object-fit: contain;
+  background: var(--md-sys-color-surface-container-highest);
+  box-shadow: 0 14px 36px rgba(15, 20, 25, 0.16);
+}
+
+.screenshot-dialog-caption {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--app-secondary-text-color);
+  text-align: center;
 }
 
 .preview-header h2 {
@@ -766,6 +853,10 @@ md-filled-tonal-button md-icon[slot='icon'] {
   gap: 1rem;
 }
 
+.builder-card.filtered-out {
+  display: none;
+}
+
 .builder-card-header {
   display: flex;
   justify-content: space-between;
@@ -781,9 +872,37 @@ md-filled-tonal-button md-icon[slot='icon'] {
 }
 
 .builder-card-fields {
-  display: flex;
-  flex-direction: column;
+  display: grid;
   gap: 1rem;
+}
+
+.builder-card-grid {
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+}
+
+.builder-field-group {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.builder-hint-chip-set {
+  display: flex;
+  gap: 0.35rem;
+  flex-wrap: wrap;
+}
+
+.builder-hint-chip {
+  --md-assist-chip-container-shape: 999px;
+  --md-assist-chip-label-text-size: 0.78rem;
+  color: var(--app-secondary-text-color);
+}
+
+.builder-hint-chip[data-state='warning'] {
+  --md-assist-chip-label-text-color: var(--md-sys-color-error);
+}
+
+.builder-hint-chip[data-state='complete'] {
+  --md-assist-chip-label-text-color: var(--md-sys-color-primary);
 }
 
 .builder-subsection {
@@ -794,6 +913,90 @@ md-filled-tonal-button md-icon[slot='icon'] {
   display: flex;
   flex-direction: column;
   gap: 0.75rem;
+}
+
+.builder-screenshots md-text-button {
+  align-self: start;
+}
+
+.screenshot-list {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.screenshot-item {
+  --md-list-item-container-shape: 16px;
+  border-radius: 16px;
+  transition: box-shadow 140ms ease, transform 140ms ease;
+}
+
+.screenshot-item.dragging {
+  opacity: 0.6;
+}
+
+.screenshot-item.drag-over {
+  box-shadow: 0 0 0 2px rgba(88, 101, 242, 0.35);
+}
+
+.screenshot-start {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+}
+
+.screenshot-drag-handle {
+  cursor: grab;
+  color: var(--app-secondary-text-color);
+}
+
+.screenshot-thumbnail {
+  width: 56px;
+  height: 56px;
+  border-radius: 12px;
+  background: var(--md-sys-color-surface-container-highest);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+  overflow: hidden;
+}
+
+.screenshot-thumbnail img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+
+.screenshot-thumbnail[data-state='loading'] img {
+  opacity: 0.4;
+}
+
+.screenshot-thumbnail[data-state='empty']::after,
+.screenshot-thumbnail[data-state='error']::after,
+.screenshot-thumbnail[data-state='loading']::after {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-size: 0.7rem;
+  text-align: center;
+  padding: 0.25rem;
+}
+
+.screenshot-thumbnail[data-state='empty']::after {
+  content: 'No image';
+  color: var(--app-secondary-text-color);
+}
+
+.screenshot-thumbnail[data-state='loading']::after {
+  content: 'Loading…';
+  color: var(--app-secondary-text-color);
+}
+
+.screenshot-thumbnail[data-state='error']::after {
+  content: 'Load error';
+  color: var(--md-sys-color-error);
 }
 
 .builder-subsection h4 {
@@ -870,7 +1073,6 @@ md-filled-tonal-button md-icon[slot='icon'] {
 
 /* --- Collection Rows --- */
 .custom-field-list,
-.screenshot-list,
 .tag-list {
   display: flex;
   flex-direction: column;
@@ -878,7 +1080,6 @@ md-filled-tonal-button md-icon[slot='icon'] {
 }
 
 .custom-field-row,
-.screenshot-row,
 .tag-row {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(0, 1fr) auto;
@@ -890,15 +1091,51 @@ md-filled-tonal-button md-icon[slot='icon'] {
   grid-template-columns: minmax(0, 1fr) auto;
 }
 
-.screenshot-row {
-  grid-template-columns: minmax(0, 1fr) auto;
-}
-
 /* --- Misc --- */
 .preview-actions md-filled-tonal-button,
 .preview-actions md-outlined-button {
   --md-filled-tonal-button-container-shape: 999px;
   --md-outlined-button-container-shape: 999px;
+}
+
+.focus-dialog {
+  --md-dialog-container-shape: 28px;
+  max-width: 640px;
+}
+
+.focus-dialog-content {
+  display: grid;
+  gap: 1rem;
+}
+
+.focus-dialog-timer {
+  font-size: 2.6rem;
+  font-weight: 600;
+  text-align: center;
+  color: var(--app-text-color);
+}
+
+.focus-dialog-controls {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+  justify-content: center;
+}
+
+.focus-dialog-checklist h3 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--app-text-color);
+}
+
+.focus-checklist {
+  max-height: 220px;
+  overflow: auto;
+}
+
+.focus-checklist md-list-item {
+  --md-list-item-container-shape: 14px;
 }
 
 .hero-visual dotlottie-player {

--- a/assets/js/apis/appToolkit.js
+++ b/assets/js/apis/appToolkit.js
@@ -11,6 +11,40 @@
         release: 'App Toolkit/release/en/home/api_android_apps.json'
     };
     const MIN_GITHUB_TOKEN_LENGTH = 20;
+    const GOOGLE_PLAY_CATEGORIES = [
+        'Art & Design',
+        'Auto & Vehicles',
+        'Beauty',
+        'Books & Reference',
+        'Business',
+        'Comics',
+        'Communication',
+        'Dating',
+        'Education',
+        'Entertainment',
+        'Events',
+        'Finance',
+        'Food & Drink',
+        'Health & Fitness',
+        'House & Home',
+        'Libraries & Demo',
+        'Lifestyle',
+        'Maps & Navigation',
+        'Medical',
+        'Music & Audio',
+        'News & Magazines',
+        'Parenting',
+        'Personalization',
+        'Photography',
+        'Productivity',
+        'Shopping',
+        'Social',
+        'Sports',
+        'Tools',
+        'Travel & Local',
+        'Video Players & Editors',
+        'Weather'
+    ];
 
     function initAppToolkitWorkspace() {
         const builderRoot = document.getElementById('appToolkitBuilder');
@@ -39,8 +73,12 @@
         const githubBranchInput = document.getElementById('appToolkitGithubBranch');
         const githubMessageInput = document.getElementById('appToolkitGithubMessage');
         const githubChannelSelect = document.getElementById('appToolkitGithubChannel');
-        const githubSubmitButton = document.getElementById('appToolkitGithubSubmit');
         const githubStatus = document.getElementById('appToolkitGithubStatus');
+        const githubWizardButton = document.getElementById('appToolkitGithubWizardButton');
+        const githubDialog = document.getElementById('appToolkitGithubDialog');
+        const githubStepper = document.getElementById('appToolkitGithubStepper');
+        const githubBackButton = document.getElementById('appToolkitGithubBack');
+        const githubNextButton = document.getElementById('appToolkitGithubNext');
         const trackedCountEl = document.getElementById('appToolkitTrackedCount');
         const releaseReadyCountEl = document.getElementById('appToolkitReleaseReadyCount');
         const screenshotAverageEl = document.getElementById('appToolkitScreenshotAverage');
@@ -49,12 +87,26 @@
         const toolbarPulseEl = document.getElementById('appToolkitToolbarPulse');
         const releaseProgressEl = document.getElementById('appToolkitReleaseProgress');
         const lastEditedEl = document.getElementById('appToolkitLastEdited');
-        const channelButtons = Array.from(
-            document.querySelectorAll('[data-app-toolkit-channel]')
-        );
-        const modeButtons = Array.from(document.querySelectorAll('[data-app-toolkit-mode]'));
+        const channelSegments = document.getElementById('appToolkitChannelSegments');
+        const modeSegments = document.getElementById('appToolkitLayoutSegments');
+        const filterChipSet = document.getElementById('appToolkitFilterChips');
         const focusButton = document.getElementById('appToolkitFocusButton');
         const notesButton = document.getElementById('appToolkitNotesButton');
+        const screenshotDialog = document.getElementById('appToolkitScreenshotDialog');
+        const screenshotDialogHeadline = document.getElementById('appToolkitScreenshotDialogHeadline');
+        const screenshotDialogImage = document.getElementById('appToolkitScreenshotDialogImage');
+        const screenshotDialogCaption = document.getElementById('appToolkitScreenshotDialogCaption');
+        const screenshotDialogOpenButton = document.getElementById('appToolkitScreenshotDialogOpen');
+        const focusDialog = document.getElementById('appToolkitFocusDialog');
+        const focusTimerEl = document.getElementById('appToolkitFocusTimer');
+        const focusStartButton = document.getElementById('appToolkitFocusStart');
+        const focusPauseButton = document.getElementById('appToolkitFocusPause');
+        const focusResetButton = document.getElementById('appToolkitFocusReset');
+        const focusSaveButton = document.getElementById('appToolkitFocusSave');
+        const focusChecklist = document.getElementById('appToolkitFocusChecklist');
+        const focusNotesField = document.getElementById('appToolkitFocusNotes');
+        const diffSheet = document.getElementById('appToolkitDiffSheet');
+        const diffContent = document.getElementById('appToolkitDiffContent');
         let sessionNotesStorage = null;
         const SESSION_NOTE_KEY = 'appToolkitWorkspaceNote';
 
@@ -64,6 +116,21 @@
         let lastPreviewState = { success: false, payload: null };
         let lastTouchedAt = null;
         let relativeTimer = null;
+        let remoteBaselinePayload = null;
+        const activeFilters = new Set();
+        let draggingScreenshot = null;
+        const FOCUS_DEFAULT_DURATION = 25 * 60;
+        let focusTimeRemaining = FOCUS_DEFAULT_DURATION;
+        let focusTimerInterval = null;
+        const GITHUB_STEPS = ['authenticate', 'target', 'review'];
+        let githubStepIndex = 0;
+        let lastMetricsSnapshot = {
+            total: 0,
+            releaseReady: 0,
+            pending: 0,
+            needsScreenshotsCount: 0,
+            missingRequiredCount: 0
+        };
         if (typeof sessionStorage !== 'undefined') {
             try {
                 sessionNotesStorage = sessionStorage;
@@ -74,6 +141,10 @@
                 sessionNotesStorage = null;
                 console.warn('AppToolkit: Session storage unavailable for workspace notes.', error);
             }
+        }
+
+        if (!sessionNotesStorage && focusSaveButton) {
+            focusSaveButton.disabled = true;
         }
 
         function createEmptyApp() {
@@ -142,10 +213,47 @@
             return output;
         }
 
-        function getSanitizedApps() {
-            return state.apps
-                .map((app) => sanitizeAppEntry(app))
-                .filter((app) => Object.keys(app).length > 0);
+        function deriveAppMeta(app, sanitized) {
+            const isEmpty = !sanitized || Object.keys(sanitized).length === 0;
+            const screenshotCount = Array.isArray(sanitized?.screenshots)
+                ? sanitized.screenshots.length
+                : 0;
+            const hasRequired = ['name', 'packageName', 'category', 'iconLogo'].every(
+                (field) => Boolean(sanitized?.[field])
+            );
+            const releaseReady = !isEmpty && hasRequired && screenshotCount >= 3;
+            const cohorts = {
+                pendingReleaseReady: !isEmpty && !releaseReady,
+                needsScreenshots: !isEmpty && screenshotCount < 3
+            };
+            return {
+                sanitized,
+                isEmpty,
+                screenshotCount,
+                hasRequired,
+                releaseReady,
+                cohorts
+            };
+        }
+
+        function getSanitizedApps({ includeMeta = false } = {}) {
+            const results = [];
+            state.apps.forEach((app, index) => {
+                const sanitized = sanitizeAppEntry(app);
+                const meta = deriveAppMeta(app, sanitized);
+                state.apps[index]._meta = meta;
+                if (!meta.isEmpty) {
+                    results.push(
+                        includeMeta
+                            ? {
+                                  index,
+                                  ...meta
+                              }
+                            : sanitized
+                    );
+                }
+            });
+            return results;
         }
 
         function formatAverage(value) {
@@ -157,21 +265,22 @@
         }
 
         function updateWorkspaceMetrics() {
-            const sanitizedApps = getSanitizedApps();
-            const total = sanitizedApps.length;
-            const releaseReady = sanitizedApps.filter((app) => {
-                const hasRequired = ['name', 'packageName', 'category', 'iconLogo'].every(
-                    (field) => Boolean(app[field])
-                );
-                const screenshotCount = Array.isArray(app.screenshots) ? app.screenshots.length : 0;
-                return hasRequired && screenshotCount >= 3;
-            }).length;
-            const screenshotTotal = sanitizedApps.reduce(
-                (count, app) => count + (Array.isArray(app.screenshots) ? app.screenshots.length : 0),
+            const sanitizedMetaEntries = getSanitizedApps({ includeMeta: true });
+            const sanitizedApps = sanitizedMetaEntries.map((entry) => entry.sanitized);
+            const total = sanitizedMetaEntries.length;
+            const releaseReady = sanitizedMetaEntries.filter((entry) => entry.releaseReady).length;
+            const screenshotTotal = sanitizedMetaEntries.reduce(
+                (count, entry) => count + entry.screenshotCount,
                 0
             );
             const averageScreenshots = total ? screenshotTotal / total : 0;
             const pending = Math.max(total - releaseReady, 0);
+            const needsScreenshotsCount = sanitizedMetaEntries.filter(
+                (entry) => entry.cohorts.needsScreenshots
+            ).length;
+            const missingRequiredCount = sanitizedMetaEntries.filter(
+                (entry) => !entry.hasRequired
+            ).length;
 
             if (trackedCountEl) {
                 trackedCountEl.textContent = String(total);
@@ -207,7 +316,15 @@
                 }
                 workspacePulseEl.textContent = message;
             }
-            return { total, releaseReady, pending };
+            refreshFocusChecklist({
+                total,
+                releaseReady,
+                pending,
+                needsScreenshotsCount,
+                missingRequiredCount
+            });
+            updateDiffSheet();
+            return { total, releaseReady, pending, needsScreenshotsCount, missingRequiredCount };
         }
 
         function extractStatusMessage(element) {
@@ -246,6 +363,303 @@
                     : 'Ready to publish';
             } else {
                 toolbarPulseEl.textContent = 'Awaiting input';
+            }
+        }
+
+        function refreshFocusChecklist(metrics = {}) {
+            if (!focusChecklist) {
+                return;
+            }
+            const snapshot = {
+                total: metrics.total || 0,
+                releaseReady: metrics.releaseReady || 0,
+                pending: metrics.pending || 0,
+                needsScreenshotsCount: metrics.needsScreenshotsCount || 0,
+                missingRequiredCount: metrics.missingRequiredCount || 0
+            };
+            lastMetricsSnapshot = snapshot;
+            focusChecklist.innerHTML = '';
+            const previewReady = validationStatus?.dataset.status === 'success';
+            const previewMessage = extractStatusMessage(validationStatus) ||
+                (previewReady ? 'Preview ready to publish.' : 'Resolve JSON validation before publishing.');
+            const pluralize = (count, singular, plural = `${singular}s`) =>
+                count === 1 ? singular : plural;
+            const items = [
+                {
+                    label: 'Add apps to workspace',
+                    detail: snapshot.total
+                        ? `${snapshot.total} ${pluralize(snapshot.total, 'app')} tracked`
+                        : 'Start by adding your first listing.',
+                    done: snapshot.total > 0
+                },
+                {
+                    label: 'Complete required metadata',
+                    detail: snapshot.missingRequiredCount
+                        ? `${snapshot.missingRequiredCount} ${pluralize(snapshot.missingRequiredCount, 'entry')} missing required fields`
+                        : 'All required fields captured.',
+                    done: snapshot.total > 0 && snapshot.missingRequiredCount === 0
+                },
+                {
+                    label: 'Provide 3+ screenshots',
+                    detail: snapshot.needsScreenshotsCount
+                        ? `${snapshot.needsScreenshotsCount} ${pluralize(snapshot.needsScreenshotsCount, 'entry')} under 3 screenshots`
+                        : 'Screenshot goals met.',
+                    done: snapshot.total > 0 && snapshot.needsScreenshotsCount === 0
+                },
+                {
+                    label: 'Validate JSON preview',
+                    detail: previewMessage,
+                    done: previewReady
+                }
+            ];
+
+            items.forEach((item) => {
+                const listItem = document.createElement('md-list-item');
+                listItem.classList.add('focus-checklist-item');
+                const checkbox = document.createElement('md-checkbox');
+                checkbox.setAttribute('slot', 'start');
+                checkbox.checked = item.done;
+                checkbox.disabled = true;
+                listItem.appendChild(checkbox);
+                const headline = document.createElement('div');
+                headline.setAttribute('slot', 'headline');
+                headline.textContent = item.label;
+                listItem.appendChild(headline);
+                if (item.detail) {
+                    const supporting = document.createElement('div');
+                    supporting.setAttribute('slot', 'supporting-text');
+                    supporting.textContent = item.detail;
+                    listItem.appendChild(supporting);
+                }
+                focusChecklist.appendChild(listItem);
+            });
+        }
+
+        function updateDiffSheet() {
+            if (!diffContent) {
+                return;
+            }
+            if (diffSheet) {
+                diffSheet.open = true;
+            }
+            if (!remoteBaselinePayload) {
+                diffContent.textContent = 'Load a baseline JSON file to compare changes.';
+                return;
+            }
+            if (!lastPreviewState.success || !lastPreviewState.payload) {
+                diffContent.textContent = 'Resolve preview errors to view the diff.';
+                return;
+            }
+            const baselineApps = extractAppsArray(remoteBaselinePayload?.data || remoteBaselinePayload) || [];
+            const currentApps = extractAppsArray(lastPreviewState.payload?.data || lastPreviewState.payload) || [];
+            const normalize = (app) => sanitizeAppEntry(app);
+            const baseline = baselineApps.map(normalize);
+            const current = currentApps.map(normalize);
+            const keyFor = (app, index) =>
+                utils.trimString(app.packageName) || utils.trimString(app.name) || `index-${index}`;
+            const baselineMap = new Map();
+            baseline.forEach((app, index) => {
+                baselineMap.set(keyFor(app, index), app);
+            });
+            const currentMap = new Map();
+            current.forEach((app, index) => {
+                currentMap.set(keyFor(app, index), app);
+            });
+            const added = [];
+            const removed = [];
+            const changed = [];
+            currentMap.forEach((value, key) => {
+                if (!baselineMap.has(key)) {
+                    added.push(value);
+                } else {
+                    const previous = baselineMap.get(key);
+                    if (JSON.stringify(previous) !== JSON.stringify(value)) {
+                        changed.push({ previous, current: value });
+                    }
+                }
+            });
+            baselineMap.forEach((value, key) => {
+                if (!currentMap.has(key)) {
+                    removed.push(value);
+                }
+            });
+            if (!added.length && !removed.length && !changed.length) {
+                diffContent.textContent = 'No differences detected since the last import.';
+                return;
+            }
+            const formatApp = (app) => app.name || app.packageName || 'Untitled app';
+            const lines = [];
+            if (added.length) {
+                lines.push('Added:');
+                added.forEach((app) => {
+                    lines.push(`  + ${formatApp(app)}`);
+                });
+            }
+            if (removed.length) {
+                lines.push('Removed:');
+                removed.forEach((app) => {
+                    lines.push(`  - ${formatApp(app)}`);
+                });
+            }
+            if (changed.length) {
+                lines.push('Updated:');
+                changed.forEach(({ previous, current: updated }) => {
+                    const diffFields = Object.keys({ ...previous, ...updated }).filter(
+                        (field) => JSON.stringify(previous[field]) !== JSON.stringify(updated[field])
+                    );
+                    lines.push(
+                        `  ~ ${formatApp(updated)} (${diffFields.join(', ') || 'content changes'})`
+                    );
+                });
+            }
+            diffContent.textContent = lines.join('\n');
+        }
+
+        function applyCardFilters() {
+            if (!entriesContainer) {
+                return;
+            }
+            const filters = Array.from(activeFilters);
+            const hasFilters = filters.length > 0;
+            const cards = entriesContainer.querySelectorAll('.builder-card');
+            cards.forEach((card) => {
+                let visible = true;
+                if (hasFilters) {
+                    visible = filters.every((filterKey) => card.dataset[filterKey] === 'true');
+                }
+                card.classList.toggle('filtered-out', !visible);
+                card.hidden = !visible;
+            });
+            if (builderRoot) {
+                builderRoot.dataset.filtered = hasFilters ? 'true' : 'false';
+            }
+        }
+
+        function syncFiltersFromChipSet() {
+            if (!filterChipSet) {
+                return;
+            }
+            activeFilters.clear();
+            const chips = filterChipSet.querySelectorAll('md-filter-chip');
+            chips.forEach((chip) => {
+                if (chip.hasAttribute('selected')) {
+                    const key = chip.dataset.appToolkitFilter;
+                    if (key) {
+                        activeFilters.add(key);
+                    }
+                }
+            });
+            applyCardFilters();
+        }
+
+        function updateFocusTimerDisplay() {
+            if (!focusTimerEl) {
+                return;
+            }
+            const minutes = Math.floor(focusTimeRemaining / 60);
+            const seconds = focusTimeRemaining % 60;
+            focusTimerEl.textContent = `${String(minutes).padStart(2, '0')}:${String(seconds).padStart(2, '0')}`;
+        }
+
+        function updateFocusControls() {
+            if (focusStartButton) {
+                focusStartButton.disabled = Boolean(focusTimerInterval);
+            }
+            if (focusPauseButton) {
+                focusPauseButton.disabled = !focusTimerInterval;
+            }
+        }
+
+        function startFocusTimer() {
+            if (typeof window === 'undefined') {
+                return;
+            }
+            if (focusTimerInterval) {
+                return;
+            }
+            if (focusTimeRemaining <= 0) {
+                focusTimeRemaining = FOCUS_DEFAULT_DURATION;
+            }
+            focusTimerInterval = window.setInterval(() => {
+                if (focusTimeRemaining <= 0) {
+                    pauseFocusTimer();
+                    focusTimeRemaining = 0;
+                    updateFocusTimerDisplay();
+                    if (toolbarPulseEl) {
+                        toolbarPulseEl.textContent = 'Focus session complete.';
+                    }
+                    return;
+                }
+                focusTimeRemaining -= 1;
+                updateFocusTimerDisplay();
+            }, 1000);
+            updateFocusControls();
+        }
+
+        function pauseFocusTimer() {
+            if (typeof window === 'undefined') {
+                return;
+            }
+            if (focusTimerInterval) {
+                window.clearInterval(focusTimerInterval);
+                focusTimerInterval = null;
+            }
+            updateFocusControls();
+        }
+
+        function resetFocusTimer() {
+            pauseFocusTimer();
+            focusTimeRemaining = FOCUS_DEFAULT_DURATION;
+            updateFocusTimerDisplay();
+        }
+
+        function openFocusDialog({ autoStart = false } = {}) {
+            if (!focusDialog) {
+                return;
+            }
+            updateFocusTimerDisplay();
+            updateFocusControls();
+            loadSavedNote();
+            focusDialog.open = true;
+            if (autoStart) {
+                resetFocusTimer();
+                startFocusTimer();
+            }
+        }
+
+        function saveSessionNote(note) {
+            if (!sessionNotesStorage) {
+                if (toolbarPulseEl) {
+                    toolbarPulseEl.textContent = 'Session notes are unavailable in this browser.';
+                }
+                return '';
+            }
+            const trimmed = utils.trimString(note);
+            if (trimmed) {
+                sessionNotesStorage.setItem(SESSION_NOTE_KEY, trimmed);
+            } else {
+                sessionNotesStorage.removeItem(SESSION_NOTE_KEY);
+            }
+            loadSavedNote();
+            return trimmed;
+        }
+
+        function setGithubStep(index) {
+            githubStepIndex = Math.max(0, Math.min(index, GITHUB_STEPS.length - 1));
+            const stepValue = GITHUB_STEPS[githubStepIndex];
+            if (githubStepper) {
+                githubStepper.value = stepValue;
+                githubStepper.setAttribute('value', stepValue);
+            }
+            const stepPanels = githubDialog?.querySelectorAll('.github-step') || [];
+            stepPanels.forEach((panel) => {
+                panel.hidden = panel.dataset.step !== stepValue;
+            });
+            if (githubBackButton) {
+                githubBackButton.disabled = githubStepIndex === 0;
+            }
+            if (githubNextButton) {
+                githubNextButton.textContent = githubStepIndex === GITHUB_STEPS.length - 1 ? 'Publish' : 'Next';
             }
         }
 
@@ -294,15 +708,31 @@
             startRelativeTimer();
         }
 
+        function syncSegmentedSelection(segmented, value) {
+            if (!segmented) {
+                return;
+            }
+            segmented.value = value;
+            segmented.querySelectorAll('md-segmented-button').forEach((button) => {
+                const buttonValue =
+                    button.getAttribute('value') ||
+                    button.dataset.appToolkitMode ||
+                    button.dataset.appToolkitChannel;
+                if (buttonValue === value) {
+                    button.setAttribute('selected', '');
+                } else {
+                    button.removeAttribute('selected');
+                }
+            });
+        }
+
         function setLayoutMode(mode) {
             if (!builderRoot) {
                 return;
             }
             const target = mode === 'compact' ? 'compact' : 'flow';
             builderRoot.dataset.layout = target;
-            modeButtons.forEach((button) => {
-                button.classList.toggle('active', button.dataset.appToolkitMode === target);
-            });
+            syncSegmentedSelection(modeSegments, target);
         }
 
         function setChannelFocus(channel) {
@@ -312,9 +742,7 @@
             const allowed = ['debug', 'release', 'both'];
             const target = allowed.includes(channel) ? channel : 'both';
             builderRoot.dataset.channel = target;
-            channelButtons.forEach((button) => {
-                button.classList.toggle('active', button.dataset.appToolkitChannel === target);
-            });
+            syncSegmentedSelection(channelSegments, target);
         }
 
         function setPreviewStatus(options) {
@@ -323,18 +751,23 @@
         }
 
         function loadSavedNote() {
-            if (!notesButton || !sessionNotesStorage) {
-                return;
+            const saved = sessionNotesStorage
+                ? sessionNotesStorage.getItem(SESSION_NOTE_KEY) || ''
+                : '';
+            if (notesButton) {
+                notesButton.dataset.noteState = saved ? 'saved' : 'empty';
+                if (saved) {
+                    notesButton.setAttribute('aria-label', 'Edit session note');
+                    notesButton.setAttribute('title', saved);
+                } else {
+                    notesButton.setAttribute('aria-label', 'Capture session note');
+                    notesButton.removeAttribute('title');
+                }
             }
-            const saved = sessionNotesStorage.getItem(SESSION_NOTE_KEY) || '';
-            notesButton.dataset.noteState = saved ? 'saved' : 'empty';
-            if (saved) {
-                notesButton.setAttribute('aria-label', 'Edit session note');
-                notesButton.setAttribute('title', saved);
-            } else {
-                notesButton.setAttribute('aria-label', 'Capture session note');
-                notesButton.removeAttribute('title');
+            if (focusNotesField) {
+                focusNotesField.value = saved;
             }
+            return saved;
         }
 
         setLayoutMode(builderRoot && builderRoot.dataset ? builderRoot.dataset.layout : 'flow');
@@ -343,6 +776,12 @@
         );
         updateLastEditedDisplay();
         loadSavedNote();
+        if (githubStepper) {
+            setGithubStep(0);
+        }
+        updateFocusTimerDisplay();
+        updateFocusControls();
+        syncFiltersFromChipSet();
 
         function render() {
             if (!entriesContainer) return;
@@ -354,10 +793,16 @@
                 entriesContainer.appendChild(createAppCard(app, index));
             });
             updatePreview();
+            applyCardFilters();
         }
 
         function createAppCard(app, index) {
-            const card = utils.createElement('div', { classNames: 'builder-card' });
+            const card = utils.createElement('div', { classNames: ['builder-card', 'app-entry-card'] });
+            card.dataset.index = String(index);
+            const meta = state.apps[index]._meta || deriveAppMeta(app, sanitizeAppEntry(app));
+            card.dataset.pendingReleaseReady = meta.cohorts.pendingReleaseReady ? 'true' : 'false';
+            card.dataset.needsScreenshots = meta.cohorts.needsScreenshots ? 'true' : 'false';
+
             const header = utils.createElement('div', { classNames: 'builder-card-header' });
             header.appendChild(utils.createElement('h3', { text: `App ${index + 1}` }));
             const removeButton = utils.createInlineButton({
@@ -378,8 +823,48 @@
             header.appendChild(removeButton);
             card.appendChild(header);
 
-            const fields = utils.createElement('div', { classNames: 'builder-card-fields' });
-            const nameField = utils.createInputField({
+            const fields = utils.createElement('div', {
+                classNames: ['builder-card-fields', 'builder-card-grid']
+            });
+
+            const createFieldGroup = (element, { assistChips } = {}) => {
+                const wrapper = utils.createElement('div', { classNames: 'builder-field-group' });
+                wrapper.appendChild(element);
+                if (assistChips) {
+                    wrapper.appendChild(assistChips);
+                }
+                fields.appendChild(wrapper);
+            };
+
+            const buildFilledTextField = ({
+                label,
+                value = '',
+                placeholder = '',
+                rows = 3,
+                multiline = false,
+                type = 'text',
+                onInput = () => {}
+            }) => {
+                const field = document.createElement('md-filled-text-field');
+                field.setAttribute('label', label);
+                if (placeholder) {
+                    field.setAttribute('placeholder', placeholder);
+                }
+                if (multiline) {
+                    field.setAttribute('multiline', '');
+                    field.setAttribute('rows', String(rows));
+                }
+                if (type !== 'text') {
+                    field.setAttribute('type', type);
+                }
+                field.value = value || '';
+                field.addEventListener('input', (event) => {
+                    onInput(event.target.value);
+                });
+                return field;
+            };
+
+            const nameField = buildFilledTextField({
                 label: 'App name',
                 value: app.name,
                 onInput: (value) => {
@@ -388,9 +873,22 @@
                     updatePreview();
                 }
             });
-            fields.appendChild(nameField.wrapper);
+            createFieldGroup(nameField);
 
-            const packageField = utils.createInputField({
+            const packageChipSet = document.createElement('md-assist-chip-set');
+            packageChipSet.classList.add('builder-hint-chip-set');
+            const packageChip = document.createElement('md-assist-chip');
+            packageChip.textContent = 'Use reverse-domain IDs (e.g., com.example.app)';
+            packageChip.classList.add('builder-hint-chip');
+            packageChipSet.appendChild(packageChip);
+
+            const updatePackageChip = (value) => {
+                const trimmed = utils.trimString(value);
+                const pattern = /^[a-zA-Z][a-zA-Z0-9_]*(\.[a-zA-Z0-9_]+)+$/;
+                packageChip.dataset.state = trimmed && pattern.test(trimmed) ? 'complete' : 'warning';
+            };
+
+            const packageField = buildFilledTextField({
                 label: 'Package name',
                 value: app.packageName,
                 placeholder: 'com.example.app',
@@ -398,34 +896,69 @@
                     state.apps[index].packageName = value;
                     touchWorkspace();
                     updatePreview();
+                    updatePackageChip(value);
                 }
             });
-            fields.appendChild(packageField.wrapper);
+            updatePackageChip(app.packageName);
+            createFieldGroup(packageField, { assistChips: packageChipSet });
 
-            const categoryField = utils.createInputField({
-                label: 'Category',
-                value: app.category,
-                onInput: (value) => {
-                    state.apps[index].category = value;
-                    touchWorkspace();
-                    updatePreview();
+            const categorySelect = document.createElement('md-outlined-select');
+            categorySelect.setAttribute('label', 'Category');
+            const placeholderOption = document.createElement('md-select-option');
+            placeholderOption.setAttribute('value', '');
+            placeholderOption.textContent = 'Select category';
+            categorySelect.appendChild(placeholderOption);
+            const knownValues = new Set();
+            GOOGLE_PLAY_CATEGORIES.forEach((category) => {
+                const option = document.createElement('md-select-option');
+                option.setAttribute('value', category);
+                option.textContent = category;
+                if (category === app.category) {
+                    option.setAttribute('selected', '');
                 }
+                knownValues.add(category);
+                categorySelect.appendChild(option);
             });
-            fields.appendChild(categoryField.wrapper);
+            if (app.category && !knownValues.has(app.category)) {
+                const customOption = document.createElement('md-select-option');
+                customOption.setAttribute('value', app.category);
+                customOption.textContent = app.category;
+                customOption.setAttribute('selected', '');
+                categorySelect.appendChild(customOption);
+            }
+            categorySelect.addEventListener('change', () => {
+                state.apps[index].category = categorySelect.value || '';
+                touchWorkspace();
+                updatePreview();
+            });
+            createFieldGroup(categorySelect);
 
-            const descriptionField = utils.createTextareaField({
+            const descriptionField = buildFilledTextField({
                 label: 'Description',
                 value: app.description,
-                rows: 3,
+                multiline: true,
+                rows: 4,
                 onInput: (value) => {
                     state.apps[index].description = value;
                     touchWorkspace();
                     updatePreview();
                 }
             });
-            fields.appendChild(descriptionField.wrapper);
+            createFieldGroup(descriptionField);
 
-            const iconField = utils.createInputField({
+            const iconChipSet = document.createElement('md-assist-chip-set');
+            iconChipSet.classList.add('builder-hint-chip-set');
+            const iconChip = document.createElement('md-assist-chip');
+            iconChip.textContent = 'Use HTTPS image URLs (512×512 recommended)';
+            iconChip.classList.add('builder-hint-chip');
+            iconChipSet.appendChild(iconChip);
+
+            const updateIconChip = (value) => {
+                const trimmed = utils.trimString(value);
+                iconChip.dataset.state = trimmed && /^https:\/\//i.test(trimmed) ? 'complete' : 'warning';
+            };
+
+            const iconField = buildFilledTextField({
                 label: 'Icon URL',
                 value: app.iconLogo,
                 placeholder: 'https://example.com/icon.png',
@@ -433,61 +966,258 @@
                     state.apps[index].iconLogo = value;
                     touchWorkspace();
                     updatePreview();
+                    updateIconChip(value);
                 }
             });
-            fields.appendChild(iconField.wrapper);
+            updateIconChip(app.iconLogo);
+            createFieldGroup(iconField, { assistChips: iconChipSet });
 
-            const screenshotsSection = utils.createElement('div', { classNames: 'builder-subsection' });
+            const screenshotsSection = utils.createElement('div', {
+                classNames: ['builder-subsection', 'builder-screenshots']
+            });
             screenshotsSection.appendChild(utils.createElement('h4', { text: 'Screenshots' }));
-            const screenshotsList = utils.createElement('div', { classNames: 'screenshot-list' });
+            const screenshotsList = document.createElement('md-list');
+            screenshotsList.classList.add('screenshot-list');
+            screenshotsList.dataset.appIndex = String(index);
+
+            const handleDragStart = (event) => {
+                const item = event.target.closest('md-list-item[data-screenshot-index]');
+                if (!item) {
+                    return;
+                }
+                draggingScreenshot = {
+                    appIndex: index,
+                    from: Number(item.dataset.screenshotIndex)
+                };
+                event.dataTransfer.effectAllowed = 'move';
+                event.dataTransfer.setData('text/plain', item.dataset.screenshotIndex);
+                item.classList.add('dragging');
+            };
+
+            const handleDragEnd = (event) => {
+                const item = event.target.closest('md-list-item[data-screenshot-index]');
+                if (item) {
+                    item.classList.remove('dragging');
+                }
+                draggingScreenshot = null;
+                screenshotsList.querySelectorAll('.drag-over').forEach((el) => el.classList.remove('drag-over'));
+            };
+
+            const handleDragOver = (event) => {
+                if (!draggingScreenshot || draggingScreenshot.appIndex !== index) {
+                    return;
+                }
+                const item = event.target.closest('md-list-item[data-screenshot-index]');
+                event.preventDefault();
+                if (item) {
+                    screenshotsList.querySelectorAll('.drag-over').forEach((el) => el.classList.remove('drag-over'));
+                    item.classList.add('drag-over');
+                }
+            };
+
+            const handleDrop = (event) => {
+                if (!draggingScreenshot || draggingScreenshot.appIndex !== index) {
+                    return;
+                }
+                event.preventDefault();
+                const item = event.target.closest('md-list-item[data-screenshot-index]');
+                let targetIndex = item ? Number(item.dataset.screenshotIndex) : state.apps[index].screenshots.length - 1;
+                if (item) {
+                    const rect = item.getBoundingClientRect();
+                    const offset = event.clientY - rect.top;
+                    if (offset > rect.height / 2) {
+                        targetIndex += 1;
+                    }
+                } else {
+                    targetIndex += 1;
+                }
+                moveScreenshot(index, draggingScreenshot.from, targetIndex);
+            };
+
+            screenshotsList.addEventListener('dragstart', handleDragStart);
+            screenshotsList.addEventListener('dragend', handleDragEnd);
+            screenshotsList.addEventListener('dragover', handleDragOver);
+            screenshotsList.addEventListener('drop', handleDrop);
+
             app.screenshots.forEach((url, screenshotIndex) => {
                 screenshotsList.appendChild(createScreenshotField(index, screenshotIndex, url));
             });
-            const addScreenshotButton = utils.createInlineButton({
-                label: 'Add screenshot',
-                icon: 'add',
-                onClick: () => {
-                    state.apps[index].screenshots.push('');
-                    touchWorkspace();
-                    render();
-                }
+
+            const addScreenshotButton = document.createElement('md-text-button');
+            const addIcon = document.createElement('md-icon');
+            addIcon.setAttribute('slot', 'icon');
+            addIcon.innerHTML = '<span class="material-symbols-outlined">add</span>';
+            addScreenshotButton.appendChild(addIcon);
+            addScreenshotButton.appendChild(document.createTextNode('Add screenshot'));
+            addScreenshotButton.addEventListener('click', () => {
+                state.apps[index].screenshots.push('');
+                touchWorkspace();
+                render();
             });
+
             screenshotsSection.appendChild(screenshotsList);
             screenshotsSection.appendChild(addScreenshotButton);
-
             fields.appendChild(screenshotsSection);
             card.appendChild(fields);
             return card;
         }
 
+        function moveScreenshot(appIndex, from, to) {
+            const list = state.apps[appIndex]?.screenshots;
+            if (!Array.isArray(list)) {
+                return;
+            }
+            if (from === to || from < 0 || from >= list.length) {
+                return;
+            }
+            let targetIndex = typeof to === 'number' ? to : list.length - 1;
+            if (targetIndex < 0) {
+                targetIndex = 0;
+            }
+            if (targetIndex > list.length) {
+                targetIndex = list.length;
+            }
+            const [moved] = list.splice(from, 1);
+            if (targetIndex > from) {
+                targetIndex -= 1;
+            }
+            list.splice(targetIndex, 0, moved);
+            touchWorkspace();
+            render();
+        }
+
         function createScreenshotField(appIndex, screenshotIndex, value) {
-            const row = utils.createElement('div', { classNames: 'screenshot-row' });
-            const field = utils.createInputField({
-                label: `Screenshot ${screenshotIndex + 1}`,
-                value,
-                placeholder: 'https://example.com/screenshot.png',
-                onInput: (text) => {
-                    state.apps[appIndex].screenshots[screenshotIndex] = text;
-                    touchWorkspace();
-                    updatePreview();
-                }
+            const item = document.createElement('md-list-item');
+            item.classList.add('screenshot-item');
+            item.dataset.appIndex = String(appIndex);
+            item.dataset.screenshotIndex = String(screenshotIndex);
+            item.setAttribute('draggable', 'true');
+
+            const startContainer = document.createElement('div');
+            startContainer.setAttribute('slot', 'start');
+            startContainer.classList.add('screenshot-start');
+
+            const dragHandle = document.createElement('md-icon-button');
+            dragHandle.classList.add('screenshot-drag-handle');
+            dragHandle.innerHTML = '<span class="material-symbols-outlined">drag_indicator</span>';
+            startContainer.appendChild(dragHandle);
+
+            const thumbnailWrapper = document.createElement('div');
+            thumbnailWrapper.classList.add('screenshot-thumbnail');
+            const thumbnail = document.createElement('img');
+            thumbnail.alt = `Screenshot ${screenshotIndex + 1}`;
+            thumbnail.decoding = 'async';
+            thumbnail.referrerPolicy = 'no-referrer';
+            thumbnailWrapper.appendChild(thumbnail);
+            startContainer.appendChild(thumbnailWrapper);
+            item.appendChild(startContainer);
+
+            const headlineContainer = document.createElement('div');
+            headlineContainer.setAttribute('slot', 'headline');
+            const textField = document.createElement('md-filled-text-field');
+            textField.setAttribute('label', `Screenshot ${screenshotIndex + 1}`);
+            textField.setAttribute('placeholder', 'https://example.com/screenshot.png');
+            textField.value = value || '';
+            textField.addEventListener('input', (event) => {
+                const nextValue = event.target.value;
+                state.apps[appIndex].screenshots[screenshotIndex] = nextValue;
+                updateThumbnail(nextValue);
+                touchWorkspace();
+                updatePreview();
             });
-            row.appendChild(field.wrapper);
-            const removeButton = utils.createInlineButton({
-                label: 'Remove',
-                icon: 'close',
-                title: 'Remove screenshot',
-                onClick: () => {
-                    state.apps[appIndex].screenshots.splice(screenshotIndex, 1);
-                    if (!state.apps[appIndex].screenshots.length) {
-                        state.apps[appIndex].screenshots.push('');
-                    }
-                    touchWorkspace();
-                    render();
-                }
+            headlineContainer.appendChild(textField);
+            item.appendChild(headlineContainer);
+
+            const openButton = document.createElement('md-icon-button');
+            openButton.setAttribute('slot', 'end');
+            openButton.setAttribute('aria-label', 'Preview screenshot');
+            openButton.innerHTML = '<span class="material-symbols-outlined">visibility</span>';
+            openButton.addEventListener('click', (event) => {
+                event.stopPropagation();
+                openScreenshotDialog(state.apps[appIndex].screenshots[screenshotIndex], {
+                    title: `Screenshot ${screenshotIndex + 1}`,
+                    packageName: state.apps[appIndex].packageName || state.apps[appIndex].name || ''
+                });
             });
-            row.appendChild(removeButton);
-            return row;
+            item.appendChild(openButton);
+
+            const removeButton = document.createElement('md-icon-button');
+            removeButton.setAttribute('slot', 'end');
+            removeButton.setAttribute('aria-label', 'Remove screenshot');
+            removeButton.innerHTML = '<span class="material-symbols-outlined">delete</span>';
+            removeButton.addEventListener('click', (event) => {
+                event.stopPropagation();
+                state.apps[appIndex].screenshots.splice(screenshotIndex, 1);
+                if (!state.apps[appIndex].screenshots.length) {
+                    state.apps[appIndex].screenshots.push('');
+                }
+                touchWorkspace();
+                render();
+            });
+            item.appendChild(removeButton);
+
+            const updateThumbnail = (url) => {
+                const trimmed = utils.trimString(url);
+                if (!trimmed) {
+                    thumbnail.removeAttribute('src');
+                    thumbnailWrapper.dataset.state = 'empty';
+                    return;
+                }
+                thumbnailWrapper.dataset.state = 'loading';
+                thumbnail.src = trimmed;
+            };
+
+            thumbnail.addEventListener('load', () => {
+                thumbnailWrapper.dataset.state = 'ready';
+            });
+            thumbnail.addEventListener('error', () => {
+                thumbnailWrapper.dataset.state = 'error';
+            });
+
+            item.addEventListener('dblclick', () => {
+                openScreenshotDialog(state.apps[appIndex].screenshots[screenshotIndex], {
+                    title: `Screenshot ${screenshotIndex + 1}`,
+                    packageName: state.apps[appIndex].packageName || state.apps[appIndex].name || ''
+                });
+            });
+
+            updateThumbnail(value);
+            return item;
+        }
+
+        function openScreenshotDialog(url, { title = 'Screenshot preview', packageName = '' } = {}) {
+            if (!screenshotDialog || !screenshotDialogImage || !screenshotDialogCaption) {
+                return;
+            }
+            const trimmed = utils.trimString(url);
+            if (screenshotDialogHeadline) {
+                screenshotDialogHeadline.textContent = title;
+            }
+            if (trimmed) {
+                screenshotDialogImage.removeAttribute('hidden');
+                screenshotDialogImage.src = trimmed;
+                screenshotDialogImage.alt = packageName ? `${title} · ${packageName}` : title;
+                screenshotDialogCaption.textContent = packageName ? `${packageName}` : trimmed;
+            } else {
+                screenshotDialogImage.setAttribute('hidden', 'true');
+                screenshotDialogImage.removeAttribute('src');
+                screenshotDialogImage.alt = 'No screenshot available';
+                screenshotDialogCaption.textContent = 'Provide a screenshot URL to preview it here.';
+            }
+            if (screenshotDialogOpenButton) {
+                if (trimmed) {
+                    screenshotDialogOpenButton.disabled = false;
+                    screenshotDialogOpenButton.onclick = () => {
+                        if (typeof window !== 'undefined') {
+                            window.open(trimmed, '_blank', 'noopener');
+                        }
+                    };
+                } else {
+                    screenshotDialogOpenButton.disabled = true;
+                    screenshotDialogOpenButton.onclick = null;
+                }
+            }
+            screenshotDialog.open = true;
         }
 
         function importJson(text) {
@@ -603,6 +1333,10 @@
                 }
                 const text = await response.text();
                 importJson(text);
+                remoteBaselinePayload = lastPreviewState.payload
+                    ? utils.cloneJson(lastPreviewState.payload)
+                    : null;
+                updateDiffSheet();
                 if (fetchButton) {
                     setLoadingState(fetchButton, false);
                     flashButton(
@@ -757,7 +1491,7 @@
         }
 
         async function publishToGithub() {
-            if (!githubSubmitButton) {
+            if (!githubNextButton) {
                 return;
             }
 
@@ -766,19 +1500,16 @@
                 token = validateGithubToken(githubTokenInput ? githubTokenInput.value : '');
             } catch (error) {
                 setGithubStatus({ status: 'error', message: error.message });
-                alert(error.message);
                 return;
             }
 
             if (!validationStatus || validationStatus.dataset.status !== 'success' || !lastPreviewState.success) {
                 setGithubStatus({ status: 'error', message: 'Resolve JSON validation issues before publishing.' });
-                alert('Resolve JSON validation issues shown in the preview before publishing.');
                 return;
             }
 
             if (!previewArea || !previewArea.value.trim()) {
                 setGithubStatus({ status: 'error', message: 'No JSON payload available to publish.' });
-                alert('There is no JSON payload to publish.');
                 return;
             }
 
@@ -787,7 +1518,6 @@
                 repository = parseRepository(githubRepoInput ? githubRepoInput.value : '');
             } catch (error) {
                 setGithubStatus({ status: 'error', message: error.message });
-                alert(error.message);
                 return;
             }
 
@@ -805,7 +1535,10 @@
             const jsonText = previewArea.value;
             const encodedContent = encodeContentToBase64(jsonText);
 
-            setLoadingState(githubSubmitButton, true, 'Publishing…');
+            setLoadingState(githubNextButton, true, 'Publishing…');
+            if (githubBackButton) {
+                githubBackButton.disabled = true;
+            }
 
             try {
                 const headers = {
@@ -885,7 +1618,7 @@
                     message: `Published ${summary} to ${repository.owner}/${repository.repo}@${branch}.`
                 });
                 flashButton(
-                    githubSubmitButton,
+                    githubNextButton,
                     '<span class="material-symbols-outlined">check</span><span>Published</span>'
                 );
             } catch (error) {
@@ -894,9 +1627,11 @@
                     status: 'error',
                     message: error.message || 'GitHub publish request failed.'
                 });
-                alert(error.message || 'GitHub publish request failed.');
             } finally {
-                setLoadingState(githubSubmitButton, false);
+                setLoadingState(githubNextButton, false);
+                if (githubBackButton) {
+                    githubBackButton.disabled = githubStepIndex === 0;
+                }
             }
         }
 
@@ -913,6 +1648,8 @@
                 state.apps = [createEmptyApp()];
                 touchWorkspace();
                 render();
+                remoteBaselinePayload = null;
+                updateDiffSheet();
             });
         }
 
@@ -974,80 +1711,154 @@
             });
         }
 
-        if (githubSubmitButton) {
-            githubSubmitButton.addEventListener('click', () => {
-                publishToGithub();
+        if (githubWizardButton && githubDialog) {
+            githubWizardButton.addEventListener('click', () => {
+                clearGithubStatus();
+                setGithubStep(0);
+                githubDialog.open = true;
             });
         }
 
-        if (channelButtons.length) {
-            channelButtons.forEach((button) => {
-                button.addEventListener('click', () => {
-                    const targetChannel = button.dataset.appToolkitChannel;
-                    setChannelFocus(targetChannel);
-                    if (toolbarPulseEl) {
-                        const label = button.textContent ? button.textContent.trim() : targetChannel;
-                        toolbarPulseEl.textContent = `Channel focus · ${label}`;
-                    }
+        if (githubDialog) {
+            ['close', 'cancel'].forEach((eventName) => {
+                githubDialog.addEventListener(eventName, () => {
+                    setGithubStep(0);
+                    clearGithubStatus();
+                    setLoadingState(githubNextButton, false);
                 });
             });
         }
 
-        if (modeButtons.length) {
-            modeButtons.forEach((button) => {
-                button.addEventListener('click', () => {
-                    const targetMode = button.dataset.appToolkitMode;
-                    setLayoutMode(targetMode);
-                    if (toolbarPulseEl) {
-                        toolbarPulseEl.textContent =
-                            targetMode === 'compact'
-                                ? 'Compact view · Focus on one listing at a time'
-                                : 'Flow view · Side-by-side with preview';
+        if (githubBackButton) {
+            githubBackButton.addEventListener('click', () => {
+                if (githubStepIndex > 0) {
+                    setGithubStep(githubStepIndex - 1);
+                    clearGithubStatus();
+                }
+            });
+        }
+
+        if (githubNextButton) {
+            githubNextButton.addEventListener('click', async () => {
+                clearGithubStatus();
+                if (githubStepIndex === 0) {
+                    try {
+                        validateGithubToken(githubTokenInput ? githubTokenInput.value : '');
+                        setGithubStep(1);
+                    } catch (error) {
+                        setGithubStatus({ status: 'error', message: error.message });
                     }
-                });
+                    return;
+                }
+                if (githubStepIndex === 1) {
+                    try {
+                        parseRepository(githubRepoInput ? githubRepoInput.value : '');
+                    } catch (error) {
+                        setGithubStatus({ status: 'error', message: error.message });
+                        return;
+                    }
+                    setGithubStep(2);
+                    updateDiffSheet();
+                    return;
+                }
+                await publishToGithub();
+            });
+        }
+
+        if (channelSegments) {
+            const handleChannelChange = (event) => {
+                const value = event?.target?.value || channelSegments.value || 'both';
+                setChannelFocus(value);
+                if (toolbarPulseEl) {
+                    const label = value === 'both'
+                        ? 'Dual'
+                        : value.charAt(0).toUpperCase() + value.slice(1);
+                    toolbarPulseEl.textContent = `Channel focus · ${label}`;
+                }
+            };
+            channelSegments.addEventListener('change', handleChannelChange);
+            channelSegments.addEventListener('input', handleChannelChange);
+        }
+
+        if (modeSegments) {
+            const handleModeChange = (event) => {
+                const value = event?.target?.value || modeSegments.value || 'flow';
+                setLayoutMode(value);
+                if (toolbarPulseEl) {
+                    toolbarPulseEl.textContent =
+                        value === 'compact'
+                            ? 'Compact view · Focus on one listing at a time'
+                            : 'Flow view · Side-by-side with preview';
+                }
+            };
+            modeSegments.addEventListener('change', handleModeChange);
+            modeSegments.addEventListener('input', handleModeChange);
+        }
+
+        if (filterChipSet) {
+            filterChipSet.addEventListener('change', () => {
+                syncFiltersFromChipSet();
+            });
+            filterChipSet.addEventListener('click', () => {
+                syncFiltersFromChipSet();
             });
         }
 
         if (focusButton) {
             focusButton.addEventListener('click', () => {
-                const current = builderRoot && builderRoot.dataset.layout === 'compact';
-                const next = current ? 'flow' : 'compact';
-                setLayoutMode(next);
+                openFocusDialog({ autoStart: true });
                 if (toolbarPulseEl) {
-                    toolbarPulseEl.textContent =
-                        next === 'compact'
-                            ? 'Focus mode enabled · Compact layout'
-                            : 'Flow layout restored';
+                    toolbarPulseEl.textContent = 'Focus session started.';
                 }
             });
         }
 
         if (notesButton) {
             notesButton.addEventListener('click', () => {
-                if (!sessionNotesStorage) {
-                    alert('Session notes are unavailable in this environment.');
-                    return;
+                openFocusDialog({ autoStart: false });
+                if (toolbarPulseEl) {
+                    toolbarPulseEl.textContent = 'Review or capture session notes.';
                 }
-                const existing = sessionNotesStorage.getItem(SESSION_NOTE_KEY) || '';
-                const note = typeof window !== 'undefined'
-                    ? window.prompt('Capture a quick note for this workspace:', existing)
-                    : existing;
-                if (note === null || note === undefined) {
-                    return;
+            });
+        }
+
+        if (focusDialog) {
+            ['close', 'cancel'].forEach((eventName) => {
+                focusDialog.addEventListener(eventName, () => {
+                    pauseFocusTimer();
+                    loadSavedNote();
+                });
+            });
+        }
+
+        if (focusStartButton) {
+            focusStartButton.addEventListener('click', () => {
+                startFocusTimer();
+            });
+        }
+
+        if (focusPauseButton) {
+            focusPauseButton.addEventListener('click', () => {
+                pauseFocusTimer();
+            });
+        }
+
+        if (focusResetButton) {
+            focusResetButton.addEventListener('click', () => {
+                resetFocusTimer();
+            });
+        }
+
+        if (focusSaveButton) {
+            focusSaveButton.addEventListener('click', () => {
+                const savedNote = saveSessionNote(focusNotesField ? focusNotesField.value : '');
+                if (toolbarPulseEl) {
+                    toolbarPulseEl.textContent = savedNote
+                        ? 'Session note saved.'
+                        : 'Session note cleared.';
                 }
-                const trimmed = note.trim();
-                if (trimmed) {
-                    sessionNotesStorage.setItem(SESSION_NOTE_KEY, trimmed);
-                    loadSavedNote();
-                    if (toolbarPulseEl) {
-                        toolbarPulseEl.textContent = 'Note saved for this session.';
-                    }
-                } else {
-                    sessionNotesStorage.removeItem(SESSION_NOTE_KEY);
-                    loadSavedNote();
-                    if (toolbarPulseEl) {
-                        toolbarPulseEl.textContent = 'Session note cleared.';
-                    }
+                if (focusDialog) {
+                    focusDialog.open = false;
                 }
             });
         }

--- a/docs/app-toolkit-ux-improvements.md
+++ b/docs/app-toolkit-ux-improvements.md
@@ -1,0 +1,44 @@
+# App Toolkit API workspace — UI & UX enhancement opportunities
+
+## Current experience snapshot
+- The workspace opens with KPI cards and pipeline guidance that rely on Material elevated and filled cards (`md-elevated-card`, `md-filled-card`) plus custom typography and icon styling.【F:pages/apis/app-toolkit.html†L11-L125】【F:assets/css/pages.css†L100-L208】
+- The builder toolbar mixes Material buttons with custom pill toggles for channel and layout selection, followed by import, fetch, and GitHub publishing panels laid out in filled cards.【F:pages/apis/app-toolkit.html†L132-L383】
+- Entry editing relies on dynamically generated builder cards, each containing text fields, textarea, and screenshot rows managed by `ApiBuilderUtils` helpers in `assets/js/apis/appToolkit.js`. Metrics, validation, and GitHub publishing states are orchestrated by the same module.【F:assets/js/apis/appToolkit.js†L61-L520】
+
+## Visual refinements & Material component upgrades
+1. **Replace custom pill toggles with segmented buttons and filter chips**
+   - Swap `.toolbar-pill` buttons for [`md-segmented-button`](https://m3.material.io/components/segmented-buttons/overview) sets to convey exclusive selection for channel focus and layout density. The current implementation manually toggles classes and aria state; segmented buttons would provide accessible selection indicators out of the box.【F:pages/apis/app-toolkit.html†L164-L205】【F:assets/js/apis/appToolkit.js†L297-L318】
+   - Introduce `md-filter-chip-set` to expose quick filters (e.g., "Needs screenshots", "Missing icons") alongside the workspace pulse, leveraging metrics already computed in `updateWorkspaceMetrics` to visually reinforce actionable cohorts.【F:assets/js/apis/appToolkit.js†L159-L211】
+
+2. **Elevate quick actions with a primary FAB and supporting bottom sheet**
+   - Promote the frequent "Add app" path into an `md-fab` anchored near the builder canvas while keeping the filled button in the toolbar for redundancy. Triggering the FAB could open a compact bottom sheet that offers shortcuts such as duplicating the most recent app, importing presets, or scanning clipboard JSON before pushing the entry into the grid.【F:pages/apis/app-toolkit.html†L132-L205】【F:assets/js/apis/appToolkit.js†L347-L459】
+   - Use a modal `md-bottom-sheet` for secondary batch actions (e.g., "Fill screenshots from shared album", "Apply release template") to avoid overloading the toolbar.
+
+3. **Transform guidance and release status into collapsible layouts**
+   - Convert the "Before you start" instructions and GitHub publishing note into `md-expansion-panel` / accordion groups so the builder canvas gains vertical space once users internalize the guidance. Persistent summary chips can surface key reminders (e.g., "Requires 3 screenshots") when panels are collapsed.【F:pages/apis/app-toolkit.html†L102-L305】
+   - For the release readiness card, incorporate an `md-linear-progress` component with dual tracks (debug/release) and place contextual help into a `md-tooltip` on the legend, reducing text density while adding affordances.【F:pages/apis/app-toolkit.html†L78-L99】【F:assets/css/pages.css†L234-L270】
+
+4. **Refine forms with adaptive field groupings**
+   - Replace stacked text fields with a responsive two-column grid using `md-filled-text-field` density tokens for wide viewports, and use `md-assist-chip` clusters near each field to surface validation hints (e.g., package name format). The existing helper methods in `createAppCard` can pass hint text and supporting icons to the Material fields.【F:assets/js/apis/appToolkit.js†L359-L436】
+   - Offer an `md-outlined-select` for categories by loading known Google Play categories from the repository, reducing free-text errors and speeding completion.【F:assets/js/apis/appToolkit.js†L405-L414】
+
+5. **Enhance screenshot management**
+   - Recast screenshot rows as draggable `md-list` items with preview thumbnails and `md-icon-button` affordances. Tie into a modal image viewer powered by `md-dialog` so curators can quickly verify URLs without leaving the workspace.【F:assets/js/apis/appToolkit.js†L440-L491】
+   - Provide batch upload support by accepting multiple URLs in a textarea dialog or enabling drag-and-drop onto the bottom sheet suggested above.
+
+## Workflow innovations to boost productivity
+- **Session focus & note taking revamp**: the existing focus and notes buttons are simple actions. Launch an `md-dialog` guided timer that combines a countdown, checklist of pending tasks (driven by `pending` count), and inline note field saved to session storage. Present captured notes inside a `md-data-table` history view for continuity between sessions.【F:pages/apis/app-toolkit.html†L60-L75】【F:assets/js/apis/appToolkit.js†L325-L346】
+- **Contextual validation banners**: augment `setPreviewStatus` and `updateToolbarPulse` so validation messages slide in via `md-banner` at the top of the builder, with action buttons ("Fix missing icon", "Jump to Screenshot 2") that focus the relevant card using existing render hooks.【F:assets/js/apis/appToolkit.js†L224-L323】
+- **Presets and automation**: extend `fetchRemoteJson` to populate an `md-menu` anchored to the fetch button that lists recent URLs and organization presets, captured in `sessionStorage`. Pair with a `md-snackbar` confirmation when data is loaded to reinforce the action.【F:pages/apis/app-toolkit.html†L208-L258】【F:assets/js/apis/appToolkit.js†L577-L606】
+- **Guided publishing wizard**: wrap the GitHub publishing form in a stepper dialog (`md-steppers` pattern) that validates token length, repository path, and branch before enabling the final submit. Surface commit preview diffs in a right-hand `md-side-sheet` so maintainers can spot differences instantly.【F:pages/apis/app-toolkit.html†L260-L381】【F:assets/js/apis/appToolkit.js†L493-L575】
+
+## Data intelligence & automation ideas
+- **Release readiness scoring**: reuse metrics from `updateWorkspaceMetrics` to produce a visual checklist showing which required fields remain. An inline `md-chip-set` can display badges like "Missing description (2)"; clicking filters the card list to relevant entries, reducing manual scanning.【F:assets/js/apis/appToolkit.js†L159-L211】
+- **Template library explorer**: introduce a `md-navigation-drawer` that slides over the JSON preview and exposes reusable entry templates (e.g., "Productivity app", "Educational app"). Selecting a template pre-fills fields and attaches recommended screenshot counts, shrinking authoring time.【F:pages/apis/app-toolkit.html†L385-L420】【F:assets/js/apis/appToolkit.js†L347-L520】
+- **Collaboration hooks**: embed a "Share session" bottom sheet that exports the current state as a GitHub Gist via API and returns a shareable link, tying into the existing GitHub auth flow. Pair with `md-icon-button` tooltips that show who last touched each entry when multi-user telemetry becomes available.【F:assets/js/apis/appToolkit.js†L493-L575】
+
+## Next steps
+1. Audit Material Web component versions to ensure segmented buttons, bottom sheets, and steppers are available or schedule polyfills if the current bundle lacks them.
+2. Prototype the segmented button + chip filter swap in isolation to validate accessibility and keyboard focus management before rolling out across the workspace.
+3. Validate performance impact of richer dialogs and drag interactions—`ApiBuilderUtils` may need memoization to avoid re-render thrash when cards gain previews and chips.
+4. Gather curator feedback on the proposed bottom-sheet quick actions and template drawer to prioritize which innovations drive the highest productivity gains.

--- a/pages/apis/app-toolkit.html
+++ b/pages/apis/app-toolkit.html
@@ -161,46 +161,41 @@
           <span class="toolbar-status-label">Workspace pulse</span>
           <span class="toolbar-status-value" id="appToolkitToolbarPulse">Awaiting input</span>
         </div>
-        <div class="toolbar-pills" role="group" aria-label="Channel focus">
-          <span class="toolbar-label">Channel focus</span>
-          <button
-            type="button"
-            class="toolbar-pill active"
-            data-app-toolkit-channel="both"
-          >
-            Dual
-          </button>
-          <button
-            type="button"
-            class="toolbar-pill"
-            data-app-toolkit-channel="debug"
-          >
-            Debug
-          </button>
-          <button
-            type="button"
-            class="toolbar-pill"
-            data-app-toolkit-channel="release"
-          >
-            Release
-          </button>
+        <div class="toolbar-filters" aria-label="Workspace filters">
+          <span class="toolbar-label">Focus filters</span>
+          <md-filter-chip-set id="appToolkitFilterChips" aria-label="Filter apps needing attention">
+            <md-filter-chip value="pending-release" data-app-toolkit-filter="pendingReleaseReady">
+              Pending release-ready
+            </md-filter-chip>
+            <md-filter-chip value="needs-screenshots" data-app-toolkit-filter="needsScreenshots">
+              Needs screenshots
+            </md-filter-chip>
+          </md-filter-chip-set>
         </div>
-        <div class="toolbar-pills" role="group" aria-label="Layout density">
+        <div class="toolbar-segment" aria-label="Channel focus">
+          <span class="toolbar-label">Channel focus</span>
+          <md-segmented-button-set id="appToolkitChannelSegments" aria-label="Channel focus">
+            <md-segmented-button value="both" data-app-toolkit-channel="both" selected>
+              Dual
+            </md-segmented-button>
+            <md-segmented-button value="debug" data-app-toolkit-channel="debug">
+              Debug
+            </md-segmented-button>
+            <md-segmented-button value="release" data-app-toolkit-channel="release">
+              Release
+            </md-segmented-button>
+          </md-segmented-button-set>
+        </div>
+        <div class="toolbar-segment" aria-label="Layout density">
           <span class="toolbar-label">Layout</span>
-          <button
-            type="button"
-            class="toolbar-pill active"
-            data-app-toolkit-mode="flow"
-          >
-            Flow
-          </button>
-          <button
-            type="button"
-            class="toolbar-pill"
-            data-app-toolkit-mode="compact"
-          >
-            Compact
-          </button>
+          <md-segmented-button-set id="appToolkitLayoutSegments" aria-label="Layout density">
+            <md-segmented-button value="flow" data-app-toolkit-mode="flow" selected>
+              Flow
+            </md-segmented-button>
+            <md-segmented-button value="compact" data-app-toolkit-mode="compact">
+              Compact
+            </md-segmented-button>
+          </md-segmented-button-set>
         </div>
       </div>
     </div>
@@ -290,94 +285,16 @@
             <li>Copy the token once and keep it outside of source control.</li>
           </ul>
         </div>
-        <div class="builder-github-fields">
-          <label class="api-field" for="appToolkitGithubToken">
-            <span class="api-field-label">Personal access token</span>
-            <input
-              id="appToolkitGithubToken"
-              class="api-input"
-              type="password"
-              autocomplete="off"
-              spellcheck="false"
-              placeholder="ghp_..."
-              aria-describedby="appToolkitGithubTokenHelp"
-            />
-            <span class="api-field-helper" id="appToolkitGithubTokenHelp"
-              >Use
-              <strong>Contents: Read &amp; write</strong> on fine-grained tokens or
-              the minimal <code>public_repo</code>/<code>repo</code> scope on
-              classic tokens. Paste the token or load it from a text file.</span
-            >
-          </label>
-          <div class="api-field-actions">
-            <input
-              type="file"
-              id="appToolkitGithubTokenFile"
-              accept="text/plain,.txt,.token"
-              hidden
-            />
-            <md-outlined-button
-              type="button"
-              id="appToolkitGithubTokenFileButton"
-            >
-              <md-icon slot="icon"
-                ><span class="material-symbols-outlined">description</span></md-icon
-              >
-              Load token from file
-            </md-outlined-button>
-          </div>
-          <label class="api-field" for="appToolkitGithubRepo">
-            <span class="api-field-label">Repository (owner/name)</span>
-            <input
-              id="appToolkitGithubRepo"
-              class="api-input"
-              type="text"
-              value="MihaiCristianCondrea/com.d4rk.apis"
-              spellcheck="false"
-            />
-          </label>
-          <label class="api-field" for="appToolkitGithubBranch">
-            <span class="api-field-label">Branch</span>
-            <input
-              id="appToolkitGithubBranch"
-              class="api-input"
-              type="text"
-              value="main"
-              spellcheck="false"
-            />
-          </label>
-          <label class="api-field" for="appToolkitGithubMessage">
-            <span class="api-field-label">Commit message</span>
-            <input
-              id="appToolkitGithubMessage"
-              class="api-input"
-              type="text"
-              value="chore(app-toolkit): update catalog"
-              spellcheck="false"
-            />
-          </label>
-          <label class="api-field" for="appToolkitGithubChannel">
-            <span class="api-field-label">Target channel</span>
-            <select id="appToolkitGithubChannel" class="api-select">
-              <option value="debug">Debug</option>
-              <option value="release">Release</option>
-              <option value="both">Debug &amp; Release</option>
-            </select>
-          </label>
-        </div>
-        <div class="builder-github-actions">
-          <md-filled-button id="appToolkitGithubSubmit">
+        <div class="builder-github-launch">
+          <md-filled-button id="appToolkitGithubWizardButton">
             <md-icon slot="icon"
-              ><span class="material-symbols-outlined">cloud_upload</span></md-icon
+              ><span class="material-symbols-outlined">rocket_launch</span></md-icon
             >
-            Publish JSON
+            Open publish wizard
           </md-filled-button>
-          <div
-            class="preview-validation"
-            id="appToolkitGithubStatus"
-            role="status"
-            aria-live="polite"
-          ></div>
+          <p class="builder-github-helper">
+            Validate the preview first, then follow the guided steps to publish.
+          </p>
         </div>
       </div>
     </md-filled-card>
@@ -417,6 +334,139 @@
           </md-outlined-button>
         </div>
       </aside>
+      <md-side-sheet
+        id="appToolkitDiffSheet"
+        class="builder-diff-sheet"
+        aria-label="Workspace diff"
+      >
+        <div slot="headline">Workspace diff</div>
+        <div slot="supporting-text">
+          Compare the current workspace against the last exported payload.
+        </div>
+        <div slot="content" class="diff-sheet-content">
+          <pre id="appToolkitDiffContent" aria-live="polite"></pre>
+        </div>
+      </md-side-sheet>
     </div>
   </section>
+
+  <md-dialog id="appToolkitScreenshotDialog" class="screenshot-dialog">
+    <div slot="headline" id="appToolkitScreenshotDialogHeadline">Screenshot preview</div>
+    <div slot="content" class="screenshot-dialog-content">
+      <img id="appToolkitScreenshotDialogImage" alt="Selected screenshot preview" />
+      <p id="appToolkitScreenshotDialogCaption" class="screenshot-dialog-caption"></p>
+    </div>
+    <div slot="actions">
+      <md-text-button dialog-action="close">Close</md-text-button>
+      <md-text-button id="appToolkitScreenshotDialogOpen" target="_blank">
+        Open in new tab
+      </md-text-button>
+    </div>
+  </md-dialog>
+
+  <md-dialog id="appToolkitFocusDialog" class="focus-dialog">
+    <div slot="headline">Focus session</div>
+    <div slot="content" class="focus-dialog-content">
+      <div class="focus-dialog-timer" id="appToolkitFocusTimer" aria-live="polite">25:00</div>
+      <div class="focus-dialog-controls">
+        <md-filled-tonal-button id="appToolkitFocusStart">Start</md-filled-tonal-button>
+        <md-filled-tonal-button id="appToolkitFocusPause">Pause</md-filled-tonal-button>
+        <md-text-button id="appToolkitFocusReset">Reset</md-text-button>
+      </div>
+      <div class="focus-dialog-checklist">
+        <h3>Pending checklist</h3>
+        <md-list id="appToolkitFocusChecklist" class="focus-checklist"></md-list>
+      </div>
+      <md-filled-text-field
+        id="appToolkitFocusNotes"
+        label="Session notes"
+        supporting-text="Notes are saved locally for this browser session."
+        rows="4"
+        multiline
+      ></md-filled-text-field>
+    </div>
+    <div slot="actions">
+      <md-text-button dialog-action="close">Close</md-text-button>
+      <md-filled-button id="appToolkitFocusSave">Save note</md-filled-button>
+    </div>
+  </md-dialog>
+
+  <md-dialog id="appToolkitGithubDialog" class="github-dialog">
+    <div slot="headline">Publish to GitHub</div>
+    <div slot="content" class="github-dialog-content">
+      <md-steppers id="appToolkitGithubStepper" value="authenticate">
+        <md-step value="authenticate" label="Authenticate">
+          <div class="github-step" data-step="authenticate">
+            <md-filled-text-field
+              id="appToolkitGithubToken"
+              label="Personal access token"
+              type="password"
+              autocomplete="off"
+              spellcheck="false"
+              supporting-text="Tokens require Contents: Read &amp; write access."
+            ></md-filled-text-field>
+            <div class="github-step-actions">
+              <input
+                type="file"
+                id="appToolkitGithubTokenFile"
+                accept="text/plain,.txt,.token"
+                hidden
+              />
+              <md-outlined-button id="appToolkitGithubTokenFileButton">
+                <md-icon slot="icon"
+                  ><span class="material-symbols-outlined">description</span></md-icon
+                >
+                Load token from file
+              </md-outlined-button>
+            </div>
+          </div>
+        </md-step>
+        <md-step value="target" label="Target">
+          <div class="github-step" data-step="target">
+            <md-filled-text-field
+              id="appToolkitGithubRepo"
+              label="Repository (owner/name)"
+              value="MihaiCristianCondrea/com.d4rk.apis"
+              supporting-text="Use owner/name format."
+              spellcheck="false"
+            ></md-filled-text-field>
+            <md-filled-text-field
+              id="appToolkitGithubBranch"
+              label="Branch"
+              value="main"
+              spellcheck="false"
+            ></md-filled-text-field>
+            <md-filled-text-field
+              id="appToolkitGithubMessage"
+              label="Commit message"
+              value="chore(app-toolkit): update catalog"
+              spellcheck="false"
+            ></md-filled-text-field>
+            <md-outlined-select
+              id="appToolkitGithubChannel"
+              label="Target channel"
+              value="debug"
+            >
+              <md-select-option value="debug">Debug</md-select-option>
+              <md-select-option value="release">Release</md-select-option>
+              <md-select-option value="both">Debug &amp; Release</md-select-option>
+            </md-outlined-select>
+          </div>
+        </md-step>
+        <md-step value="review" label="Review">
+          <div class="github-step" data-step="review">
+            <p class="github-review-copy">
+              Confirm the diff in the side sheet and publish when ready.
+            </p>
+            <div class="github-status" id="appToolkitGithubStatus" role="status" aria-live="polite"></div>
+          </div>
+        </md-step>
+      </md-steppers>
+    </div>
+    <div slot="actions" class="github-dialog-actions">
+      <md-text-button dialog-action="close">Cancel</md-text-button>
+      <md-text-button id="appToolkitGithubBack">Back</md-text-button>
+      <md-filled-button id="appToolkitGithubNext">Next</md-filled-button>
+    </div>
+  </md-dialog>
 </div>


### PR DESCRIPTION
## Summary
- replace channel/layout toggles with segmented controls and add Material filter chips in the toolbar
- rebuild builder cards with Material inputs, draggable screenshot lists, and supporting assist chips
- introduce focus session and screenshot dialogs plus a GitHub publish wizard with diff side sheet and stepper flow

## Testing
- not run (manual changes only)

------
https://chatgpt.com/codex/tasks/task_e_68dce12ae8d8832d9ac59ebd9234a7d5