### PR TITLE
Align App Toolkit workspace form controls

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -880,6 +880,14 @@ md-filled-tonal-button md-icon[slot='icon'] {
   grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
 }
 
+.builder-card-grid md-filled-text-field,
+.builder-card-grid md-outlined-select,
+.builder-card-grid md-assist-chip-set,
+.builder-card-grid .builder-subsection {
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .builder-field-group {
   display: grid;
   gap: 0.5rem;


### PR DESCRIPTION
## Summary
- ensure App Toolkit workspace form elements stretch to match the layout grid for consistent sizing

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68de17cd1f78832dbb80e244b0a8c61b