### PR TITLE
Center fetch button in App Toolkit workspace

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -631,6 +631,11 @@ md-filled-tonal-button md-icon[slot='icon'] {
   width: 100%;
 }
 
+.builder-remote-controls md-filled-tonal-button {
+  justify-self: center;
+  align-self: center;
+}
+
 .builder-remote-presets {
   display: flex;
   flex-wrap: wrap;


### PR DESCRIPTION
## Summary
- center the Fetch from URL button within the App Toolkit API workspace controls for consistent alignment

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68de1ac8f4e0832d8e46e33c7adad89c