### PR TITLE
feat: improve app toolkit screenshot workflow and diff viewer

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -866,6 +866,12 @@ md-filled-tonal-button md-icon[slot='icon'] {
   color: var(--app-secondary-text-color);
 }
 
+.preview-validation .export-guard {
+  margin-left: 1.5rem;
+  font-size: 0.78rem;
+  color: var(--md-sys-color-error);
+}
+
 .preview-validation[data-status='success'] {
   color: var(--md-sys-color-primary);
 }
@@ -976,6 +982,11 @@ md-filled-tonal-button md-icon[slot='icon'] {
   align-items: center;
 }
 
+.builder-icon-override {
+  margin-left: 4.25rem;
+  --md-checkbox-label-text-color: var(--app-secondary-text-color);
+}
+
 .builder-field-helper-preview {
   width: 64px;
   height: 64px;
@@ -1052,33 +1063,80 @@ md-filled-tonal-button md-icon[slot='icon'] {
   gap: 0.75rem;
 }
 
-.builder-screenshots md-text-button {
+.builder-subsection h4 {
+  margin: 0;
+  font-size: 0.95rem;
+  font-weight: 600;
+  color: var(--app-text-color);
+}
+
+
+.builder-screenshots {
+  position: relative;
+}
+
+.builder-screenshots[data-count-state='needs']::after {
+  content: 'Provide at least three screenshots to export.';
+  color: var(--md-sys-color-error);
+  font-size: 0.8rem;
+  display: block;
+  margin-top: 0.35rem;
+}
+
+.builder-screenshots md-text-button,
+.builder-screenshots md-filled-tonal-button {
   align-self: start;
+}
+
+.screenshot-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5rem;
+  align-items: center;
+}
+
+.screenshot-actions md-filled-text-field {
+  min-width: min(320px, 100%);
 }
 
 .screenshot-list {
   display: grid;
-  gap: 0.5rem;
+  gap: 0.75rem;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
 }
 
+
 .screenshot-item {
-  --md-list-item-container-shape: 16px;
-  border-radius: 16px;
+  background: var(--md-sys-color-surface-container-low);
+  border-radius: 20px;
+  padding: 1rem;
+  display: grid;
+  gap: 0.75rem;
   transition: box-shadow 140ms ease, transform 140ms ease;
+  border: 1px solid transparent;
 }
 
 .screenshot-item.dragging {
-  opacity: 0.6;
+  opacity: 0.7;
+  transform: scale(0.98);
+  box-shadow: 0 18px 40px rgba(0, 0, 0, 0.18);
 }
 
 .screenshot-item.drag-over {
-  box-shadow: 0 0 0 2px rgba(88, 101, 242, 0.35);
+  border-color: var(--md-sys-color-primary);
 }
 
-.screenshot-start {
+.screenshot-item-actions {
   display: flex;
   align-items: center;
+  justify-content: space-between;
   gap: 0.5rem;
+}
+
+.screenshot-item-actions-end {
+  display: flex;
+  align-items: center;
+  gap: 0.25rem;
 }
 
 .screenshot-drag-handle {
@@ -1086,16 +1144,22 @@ md-filled-tonal-button md-icon[slot='icon'] {
   color: var(--app-secondary-text-color);
 }
 
+.screenshot-drag-handle:focus-visible {
+  outline: 2px solid var(--md-sys-color-primary);
+  outline-offset: 2px;
+}
+
 .screenshot-thumbnail {
-  width: 56px;
-  height: 56px;
-  border-radius: 12px;
+  width: 100%;
+  aspect-ratio: 9 / 16;
+  border-radius: 16px;
   background: var(--md-sys-color-surface-container-highest);
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
   overflow: hidden;
+  border: 1px solid var(--app-border-color);
 }
 
 .screenshot-thumbnail img {
@@ -1136,11 +1200,173 @@ md-filled-tonal-button md-icon[slot='icon'] {
   color: var(--md-sys-color-error);
 }
 
-.builder-subsection h4 {
-  margin: 0;
-  font-size: 0.95rem;
+
+.screenshot-info {
+  display: grid;
+  gap: 0.5rem;
+}
+
+.screenshot-meta {
+  font-size: 0.75rem;
+  color: var(--app-secondary-text-color);
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.screenshot-meta[data-state='error'] {
+  color: var(--md-sys-color-error);
+}
+
+.screenshot-meta kbd {
+  font-size: 0.7rem;
+  padding: 0.1rem 0.35rem;
+  border-radius: 4px;
+  background: var(--md-sys-color-surface-container);
+  border: 1px solid var(--app-border-color);
+}
+
+.screenshot-dropzone {
+  border: 1px dashed var(--app-border-color);
+  border-radius: 16px;
+  padding: 1.25rem;
+  text-align: center;
+  font-size: 0.9rem;
+  color: var(--app-secondary-text-color);
+  transition: border-color 120ms ease, background-color 120ms ease;
+  background: var(--md-sys-color-surface-container-lowest);
+}
+
+.screenshot-dropzone:focus-visible {
+  outline: 2px solid var(--md-sys-color-primary);
+  outline-offset: 2px;
+}
+
+.screenshot-dropzone[data-state='active'] {
+  border-color: var(--md-sys-color-primary);
+  background: color-mix(in srgb, var(--md-sys-color-primary) 12%, transparent);
+  color: var(--md-sys-color-primary);
+}
+
+.screenshot-dropzone strong {
+  display: block;
   font-weight: 600;
   color: var(--app-text-color);
+}
+
+.screenshot-dropzone span {
+  display: block;
+  margin-top: 0.25rem;
+}
+
+.screenshot-dropzone .shortcut {
+  font-size: 0.75rem;
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+}
+
+.screenshot-dropzone .shortcut kbd {
+  font-size: 0.7rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 4px;
+  border: 1px solid var(--app-border-color);
+}
+
+.diff-view {
+  min-height: 240px;
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  font-family: 'Google Sans', 'Inter', system-ui, -apple-system, BlinkMacSystemFont,
+    'Segoe UI', sans-serif;
+}
+
+.diff-view--empty {
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  color: var(--app-secondary-text-color);
+  font-size: 0.9rem;
+  padding: 1.5rem 1rem;
+}
+
+.diff-view__actions {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  justify-content: flex-end;
+}
+
+.diff-view__body {
+  border: 1px solid var(--app-border-color);
+  border-radius: 18px;
+  overflow: hidden;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  background: var(--md-sys-color-surface-container-lowest);
+}
+
+.diff-view__column {
+  padding: 1rem;
+  overflow: auto;
+  max-height: 420px;
+  border-inline-end: 1px solid var(--app-border-color);
+}
+
+.diff-view__column:last-child {
+  border-inline-end: none;
+}
+
+.diff-view__column > h4 {
+  font-size: 0.85rem;
+  font-weight: 600;
+  margin: 0 0 0.75rem;
+  color: var(--app-secondary-text-color);
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+
+.jsondiffpatch-delta {
+  font-family: 'Roboto Mono', 'Fira Code', 'Source Code Pro', ui-monospace, SFMono-Regular,
+    SFMono, Menlo, Monaco, Consolas, monospace;
+  font-size: 0.8rem;
+  line-height: 1.4;
+  white-space: pre-wrap;
+}
+
+.jsondiffpatch-added {
+  background: color-mix(in srgb, var(--md-sys-color-secondary) 18%, transparent);
+}
+
+.jsondiffpatch-removed {
+  background: color-mix(in srgb, var(--md-sys-color-error) 16%, transparent);
+}
+
+.jsondiffpatch-modified {
+  background: color-mix(in srgb, var(--md-sys-color-primary) 16%, transparent);
+}
+
+.jsondiffpatch-unchanged {
+  color: var(--app-secondary-text-color);
+}
+
+.jsondiffpatch-property-name {
+  color: var(--md-sys-color-primary);
+}
+
+.jsondiffpatch-property-name::after {
+  content: ':';
+  color: var(--app-secondary-text-color);
+}
+
+.diff-view__column--baseline .jsondiffpatch-added {
+  display: none;
+}
+
+.diff-view__column--current .jsondiffpatch-removed {
+  display: none;
 }
 
 .builder-subsection-header {

--- a/index.html
+++ b/index.html
@@ -104,6 +104,12 @@
     <link rel="stylesheet" href="assets/css/base.css" />
     <link rel="stylesheet" href="assets/css/components.css" />
     <link rel="stylesheet" href="assets/css/pages.css" />
+    <script
+      src="https://cdn.jsdelivr.net/npm/jsondiffpatch@0.7.3/dist/jsondiffpatch.umd.min.js"
+      integrity="sha384-k9hBYqZuhiIeZAdNgw0X29mNq2BdJvNBmlF/CaPEzgPieGEAFFSz9KlOjE7td6d7"
+      crossorigin="anonymous"
+      defer
+    ></script>
   </head>
 
   <body class="bg-surface-container-lowest">

--- a/pages/apis/app-toolkit.html
+++ b/pages/apis/app-toolkit.html
@@ -344,7 +344,12 @@
           Compare the current workspace against the last exported payload.
         </div>
         <div slot="content" class="diff-sheet-content">
-          <pre id="appToolkitDiffContent" aria-live="polite"></pre>
+          <div
+            id="appToolkitDiffContent"
+            class="diff-view diff-view--empty"
+            role="status"
+            aria-live="polite"
+          ></div>
         </div>
       </md-side-sheet>
     </div>


### PR DESCRIPTION
## Summary
- redesign the App Toolkit screenshot manager with a grid, drag and drop uploads, URL intake, previews, and count feedback tied to state
- gate exports on package name, HTTPS icon sizing with override, and minimum screenshot requirements while keeping payload serialization in sync
- integrate jsondiffpatch for a side-by-side workspace diff with compact empty states and auto-collapsing when no comparison is available

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de4cf77e9c832d947e6a987005d7f3