### PR TITLE
Improve dialog presentation and close controls

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -1,3 +1,34 @@
+/* --- Dialogs --- */
+.app-dialog {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(1rem, 3vw, 2rem);
+}
+
+.app-dialog::part(container) {
+  box-sizing: border-box;
+  max-width: min(92vw, 720px);
+  min-width: min(92vw, 320px);
+  padding: clamp(1.25rem, 3vw, 2rem);
+  margin: 0;
+}
+
+.app-dialog [slot='headline'] {
+  margin: 0 0 1rem 0;
+}
+
+.app-dialog [slot='content'] {
+  margin: 0;
+}
+
+.app-dialog [slot='actions'] {
+  display: flex;
+  justify-content: flex-end;
+  gap: 0.75rem;
+  margin-top: 1.5rem;
+}
+
 /* --- Top App Bar --- */
 md-top-app-bar {
   position: sticky;

--- a/assets/js/apis/appToolkit.js
+++ b/assets/js/apis/appToolkit.js
@@ -108,6 +108,23 @@
         const focusNotesField = document.getElementById('appToolkitFocusNotes');
         const diffSheet = document.getElementById('appToolkitDiffSheet');
         const diffContent = document.getElementById('appToolkitDiffContent');
+        const dialogsToWire = [screenshotDialog, focusDialog, githubDialog];
+        dialogsToWire.forEach((dialog) => {
+            if (!dialog || dialog.dataset.dialogCloseInit === 'true') {
+                return;
+            }
+            const closeButtons = dialog.querySelectorAll('[dialog-action="close"]');
+            closeButtons.forEach((button) => {
+                button.addEventListener('click', () => {
+                    if (typeof dialog.close === 'function') {
+                        dialog.close();
+                    } else {
+                        dialog.open = false;
+                    }
+                });
+            });
+            dialog.dataset.dialogCloseInit = 'true';
+        });
         let sessionNotesStorage = null;
         const SESSION_NOTE_KEY = 'appToolkitWorkspaceNote';
 

--- a/assets/js/contact.js
+++ b/assets/js/contact.js
@@ -13,6 +13,13 @@ function initContactPage() {
     openButton.addEventListener('click', () => {
         contactDialog.open = true;
     });
+
+    const closeButtons = contactDialog.querySelectorAll('[dialog-action="close"]');
+    closeButtons.forEach((button) => {
+        button.addEventListener('click', () => {
+            contactDialog.close();
+        });
+    });
     openButton.dataset.dialogInit = 'true';
 
     return true;

--- a/pages/apis/app-toolkit.html
+++ b/pages/apis/app-toolkit.html
@@ -355,7 +355,10 @@
     </div>
   </section>
 
-  <md-dialog id="appToolkitScreenshotDialog" class="screenshot-dialog">
+  <md-dialog
+    id="appToolkitScreenshotDialog"
+    class="app-dialog screenshot-dialog"
+  >
     <div slot="headline" id="appToolkitScreenshotDialogHeadline">Screenshot preview</div>
     <div slot="content" class="screenshot-dialog-content">
       <img id="appToolkitScreenshotDialogImage" alt="Selected screenshot preview" />
@@ -369,7 +372,7 @@
     </div>
   </md-dialog>
 
-  <md-dialog id="appToolkitFocusDialog" class="focus-dialog">
+  <md-dialog id="appToolkitFocusDialog" class="app-dialog focus-dialog">
     <div slot="headline">Focus session</div>
     <div slot="content" class="focus-dialog-content">
       <div class="focus-dialog-timer" id="appToolkitFocusTimer" aria-live="polite">25:00</div>
@@ -396,7 +399,7 @@
     </div>
   </md-dialog>
 
-  <md-dialog id="appToolkitGithubDialog" class="github-dialog">
+  <md-dialog id="appToolkitGithubDialog" class="app-dialog github-dialog">
     <div slot="headline">Publish to GitHub</div>
     <div slot="content" class="github-dialog-content">
       <md-steppers id="appToolkitGithubStepper" value="authenticate">

--- a/pages/drawer/contact.html
+++ b/pages/drawer/contact.html
@@ -82,7 +82,7 @@
     </ul>
   </div>
 </div>
-<md-dialog id="contactDialog">
+<md-dialog id="contactDialog" class="app-dialog">
   <div slot="headline">Contact Mihai</div>
   <div slot="content">
     <p>


### PR DESCRIPTION
## Summary
- add shared dialog styling to provide consistent padding and centered positioning
- wire dialog close buttons so that contact and toolkit modals can dismiss themselves
- mark dialog markup with the new shared class for consistent layout

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68de9ac5832c832d91701a6be2855e4d