### PR TITLE
Fix App Toolkit preview layout spacing

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -597,7 +597,8 @@ md-filled-tonal-button md-icon[slot='icon'] {
 }
 
 @media (max-width: 1200px) {
-  .builder-columns {
+  .builder-columns,
+  .builder-columns--with-diff {
     grid-template-columns: minmax(0, 1.6fr) minmax(280px, 1fr);
   }
   .builder-diff-sheet {
@@ -738,17 +739,22 @@ md-filled-tonal-button md-icon[slot='icon'] {
 }
 
 .builder-columns {
+  grid-template-columns: minmax(0, 2.25fr) minmax(0, 1.35fr);
+}
+
+.builder-columns--with-diff {
   grid-template-columns: minmax(0, 2.25fr) minmax(0, 1.35fr) minmax(0, 1.1fr);
 }
 
 @media (max-width: 1440px) {
-  .builder-columns {
+  .builder-columns--with-diff {
     grid-template-columns: minmax(0, 2fr) minmax(0, 1.25fr) minmax(0, 1fr);
   }
 }
 
 @media (max-width: 1024px) {
-  .builder-columns {
+  .builder-columns,
+  .builder-columns--with-diff {
     grid-template-columns: minmax(0, 1.4fr) minmax(0, 1fr);
   }
   .builder-diff-sheet {
@@ -757,7 +763,8 @@ md-filled-tonal-button md-icon[slot='icon'] {
 }
 
 @media (max-width: 768px) {
-  .builder-columns {
+  .builder-columns,
+  .builder-columns--with-diff {
     grid-template-columns: 1fr;
   }
 }

--- a/assets/js/apis/appToolkit.js
+++ b/assets/js/apis/appToolkit.js
@@ -54,6 +54,7 @@
         }
 
         const entriesContainer = document.getElementById('appToolkitEntries');
+        const builderLayout = builderRoot.querySelector('.builder-layout');
         const addButton = document.getElementById('appToolkitAddApp');
         const resetButton = document.getElementById('appToolkitResetButton');
         const copyButton = document.getElementById('appToolkitCopyButton');
@@ -668,6 +669,9 @@
                 diffContent.innerHTML = '';
                 diffContent.classList.add('diff-view--empty');
                 diffContent.textContent = message;
+                if (builderLayout) {
+                    builderLayout.classList.remove('builder-columns--with-diff');
+                }
                 if (diffSheet) {
                     diffSheet.open = false;
                     diffSheet.classList.add('is-empty');
@@ -723,6 +727,9 @@
             }
 
             diffContent.classList.remove('diff-view--empty');
+            if (builderLayout) {
+                builderLayout.classList.add('builder-columns--with-diff');
+            }
             if (diffSheet) {
                 diffSheet.classList.remove('is-empty');
                 diffSheet.open = true;


### PR DESCRIPTION
## Summary
- collapse the App Toolkit builder grid to two columns when the diff sheet is hidden
- toggle a layout modifier when the diff viewer opens so the third column reappears only when needed

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68dfb82a6458832da22bb6d79271d35f