### PR TITLE
Switch workspace cards to list layout

### DIFF
--- a/assets/css/pages.css
+++ b/assets/css/pages.css
@@ -91,10 +91,17 @@
   max-width: 65ch;
 }
 
-.workspace-grid {
-  display: grid;
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+.workspace-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
   gap: 1.5rem;
+  margin: 0;
+  padding: 0;
+}
+
+.workspace-list-item {
+  display: contents;
 }
 
 .workspace-dashboard {

--- a/index.html
+++ b/index.html
@@ -335,92 +335,98 @@
               the production JSON files so you can safely prototype or edit.
             </p>
           </div>
-          <div class="workspace-grid">
-            <md-elevated-card class="workspace-card">
-              <div class="workspace-card-header">
-                <div class="workspace-icon">
-                  <span class="material-symbols-outlined">build</span>
+          <ul class="workspace-list">
+            <li class="workspace-list-item">
+              <md-elevated-card class="workspace-card">
+                <div class="workspace-card-header">
+                  <div class="workspace-icon">
+                    <span class="material-symbols-outlined">build</span>
+                  </div>
+                  <h3>App Toolkit</h3>
                 </div>
-                <h3>App Toolkit</h3>
-              </div>
-              <p>
-                Curate tool listings, screenshots, and metadata that power the
-                App Toolkit catalog in both debug and release channels.
-              </p>
-              <ul>
-                <li>Generate app collections with drag-to-add entries</li>
-                <li>Bulk import existing JSON for review</li>
-                <li>Export formatted payloads instantly</li>
-              </ul>
-              <a class="workspace-action" href="#app-toolkit-api">
-                <md-outlined-button trailing-icon>
-                  Open workspace
-                  <md-icon slot="icon"
-                    ><span class="material-symbols-outlined"
-                      >arrow_forward</span
-                    ></md-icon
-                  >
-                </md-outlined-button>
-              </a>
-            </md-elevated-card>
-            <md-elevated-card class="workspace-card">
-              <div class="workspace-card-header">
-                <div class="workspace-icon">
-                  <span class="material-symbols-outlined">lightbulb</span>
+                <p>
+                  Curate tool listings, screenshots, and metadata that power the
+                  App Toolkit catalog in both debug and release channels.
+                </p>
+                <ul>
+                  <li>Generate app collections with drag-to-add entries</li>
+                  <li>Bulk import existing JSON for review</li>
+                  <li>Export formatted payloads instantly</li>
+                </ul>
+                <a class="workspace-action" href="#app-toolkit-api">
+                  <md-outlined-button trailing-icon>
+                    Open workspace
+                    <md-icon slot="icon"
+                      ><span class="material-symbols-outlined"
+                        >arrow_forward</span
+                      ></md-icon
+                    >
+                  </md-outlined-button>
+                </a>
+              </md-elevated-card>
+            </li>
+            <li class="workspace-list-item">
+              <md-elevated-card class="workspace-card">
+                <div class="workspace-card-header">
+                  <div class="workspace-icon">
+                    <span class="material-symbols-outlined">lightbulb</span>
+                  </div>
+                  <h3>English with Lidia</h3>
                 </div>
-                <h3>English with Lidia</h3>
-              </div>
-              <p>
-                Design home feeds and lesson flows with multimedia content,
-                audio tracks, and ads aligned with the published documentation.
-              </p>
-              <ul>
-                <li>Switch between Home and Lesson API builders</li>
-                <li>Attach audio, images, and copy in context</li>
-                <li>Preview generated JSON before exporting</li>
-              </ul>
-              <a class="workspace-action" href="#english-with-lidia-api">
-                <md-outlined-button trailing-icon>
-                  Open workspace
-                  <md-icon slot="icon"
-                    ><span class="material-symbols-outlined"
-                      >arrow_forward</span
-                    ></md-icon
-                  >
-                </md-outlined-button>
-              </a>
-            </md-elevated-card>
-            <md-elevated-card class="workspace-card">
-              <div class="workspace-card-header">
-                <div class="workspace-icon">
-                  <span class="material-symbols-outlined">school</span>
+                <p>
+                  Design home feeds and lesson flows with multimedia content,
+                  audio tracks, and ads aligned with the published documentation.
+                </p>
+                <ul>
+                  <li>Switch between Home and Lesson API builders</li>
+                  <li>Attach audio, images, and copy in context</li>
+                  <li>Preview generated JSON before exporting</li>
+                </ul>
+                <a class="workspace-action" href="#english-with-lidia-api">
+                  <md-outlined-button trailing-icon>
+                    Open workspace
+                    <md-icon slot="icon"
+                      ><span class="material-symbols-outlined"
+                        >arrow_forward</span
+                      ></md-icon
+                    >
+                  </md-outlined-button>
+                </a>
+              </md-elevated-card>
+            </li>
+            <li class="workspace-list-item">
+              <md-elevated-card class="workspace-card">
+                <div class="workspace-card-header">
+                  <div class="workspace-icon">
+                    <span class="material-symbols-outlined">school</span>
+                  </div>
+                  <h3>Android Studio Tutorials</h3>
                 </div>
-                <h3>Android Studio Tutorials</h3>
-              </div>
-              <p>
-                Assemble Compose-first lesson journeys with code samples,
-                banners, ads, and metadata tailored for the tutorials app.
-              </p>
-              <ul>
-                <li>Define home feed cards with smart defaults</li>
-                <li>Craft lesson narratives block-by-block</li>
-                <li>Document deep links and tags consistently</li>
-              </ul>
-              <a
-                class="workspace-action"
-                href="#android-studio-tutorials-api"
-              >
-                <md-outlined-button trailing-icon>
-                  Open workspace
-                  <md-icon slot="icon"
-                    ><span class="material-symbols-outlined"
-                      >arrow_forward</span
-                    ></md-icon
-                  >
-                </md-outlined-button>
-              </a>
-            </md-elevated-card>
-          </div>
+                <p>
+                  Assemble Compose-first lesson journeys with code samples,
+                  banners, ads, and metadata tailored for the tutorials app.
+                </p>
+                <ul>
+                  <li>Define home feed cards with smart defaults</li>
+                  <li>Craft lesson narratives block-by-block</li>
+                  <li>Document deep links and tags consistently</li>
+                </ul>
+                <a
+                  class="workspace-action"
+                  href="#android-studio-tutorials-api"
+                >
+                  <md-outlined-button trailing-icon>
+                    Open workspace
+                    <md-icon slot="icon"
+                      ><span class="material-symbols-outlined"
+                        >arrow_forward</span
+                      ></md-icon
+                    >
+                  </md-outlined-button>
+                </a>
+              </md-elevated-card>
+            </li>
+          </ul>
         </section>
 
         <section class="home-section">


### PR DESCRIPTION
## Summary
- replace the home page workspace grid with a semantic list structure
- update the associated styles to stack workspace cards vertically with list semantics

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dfbcf06c3c832d82a2a37158e78b55