### PR TITLE
Adjust surface container background color

### DIFF
--- a/assets/css/variables.css
+++ b/assets/css/variables.css
@@ -33,7 +33,7 @@
   --md-sys-color-surface-container-lowest: #ffffff;
   --md-sys-color-surface-container-low: #f2f5f4;
   --md-sys-color-surface-container: #ecefef;
-  --md-sys-color-surface-container-high: #e6eae9;
+  --md-sys-color-surface-container-high: #f2f5f4;
   --md-sys-color-surface-container-highest: #e1e4e4;
   --app-bg-color: var(--md-sys-color-surface-container-lowest);
   --app-text-color: var(--md-sys-color-on-surface);


### PR DESCRIPTION
## Summary
- update the surface container high color token to use #f2f5f4 so the app uses a single background shade

## Testing
- n/a

------
https://chatgpt.com/codex/tasks/task_e_68e1f88376c4832d9dfaf6d3deae9112