### PR TITLE
fix: tidy text button spacing and alignment

### DIFF
--- a/assets/css/components.css
+++ b/assets/css/components.css
@@ -336,6 +336,7 @@ md-list-item[type='button'].expanded md-icon[slot='end'] {
 :root {
   --app-button-icon-inline-padding: 16px;
   --app-text-button-icon-inline-padding: 12px;
+  --app-text-button-inline-padding: 16px;
 }
 
 md-filled-button,
@@ -1543,6 +1544,16 @@ md-text-button::part(button) {
   display: inline-flex;
   align-items: center;
   justify-content: center;
+  padding-inline-start: var(--app-text-button-inline-padding);
+  padding-inline-end: var(--app-text-button-inline-padding);
+}
+
+.screenshot-actions md-text-button {
+  align-self: stretch;
+}
+
+.screenshot-actions md-text-button::part(button) {
+  height: 100%;
 }
 
 .focus-dialog {


### PR DESCRIPTION
## Summary
- add a shared inline padding token for text buttons and apply it to button internals
- stretch the screenshot action text button so the Add URL control lines up with the URL field

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e1f9e4bef8832d8a0e98ded19862f6