### PR TITLE
Fix Material buttons with icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -296,7 +296,7 @@
             </p>
             <div class="hero-actions">
               <a href="#app-toolkit-api">
-                <md-filled-button>
+                <md-filled-button has-icon>
                   <md-icon slot="icon"
                     ><span class="material-symbols-outlined"
                       >rocket_launch</span
@@ -306,14 +306,14 @@
                 </md-filled-button>
               </a>
               <a href="#english-with-lidia-api">
-                <md-tonal-button>
+                <md-filled-tonal-button has-icon trailing-icon>
                   Explore lesson tooling
                   <md-icon slot="icon"
                     ><span class="material-symbols-outlined"
                       >menu_book</span
                     ></md-icon
                   >
-                </md-tonal-button>
+                </md-filled-tonal-button>
               </a>
             </div>
           </div>

--- a/pages/apis/android-studio-tutorials.html
+++ b/pages/apis/android-studio-tutorials.html
@@ -55,13 +55,13 @@
           data-builder-type="android-home"
         >
           <div class="builder-toolbar">
-            <md-filled-button id="androidHomeAddCard">
+            <md-filled-button id="androidHomeAddCard" has-icon>
               <md-icon slot="icon"
                 ><span class="material-symbols-outlined">add</span></md-icon
               >
               Add card
             </md-filled-button>
-            <md-outlined-button id="androidHomeImportButton">
+            <md-outlined-button id="androidHomeImportButton" has-icon>
               <md-icon slot="icon"
                 ><span class="material-symbols-outlined">upload</span></md-icon
               >
@@ -73,7 +73,7 @@
               accept="application/json"
               hidden
             />
-            <md-text-button id="androidHomeResetButton">
+            <md-text-button id="androidHomeResetButton" has-icon>
               <md-icon slot="icon"
                 ><span class="material-symbols-outlined">refresh</span></md-icon
               >
@@ -106,7 +106,7 @@
                 aria-live="polite"
               ></div>
               <div class="preview-actions">
-                <md-filled-tonal-button id="androidHomeCopyButton">
+                <md-filled-tonal-button id="androidHomeCopyButton" has-icon>
                   <md-icon slot="icon"
                     ><span class="material-symbols-outlined"
                       >content_copy</span
@@ -114,7 +114,11 @@
                   >
                   Copy JSON
                 </md-filled-tonal-button>
-                <md-outlined-button id="androidHomeDownloadButton" trailing-icon>
+                <md-outlined-button
+                  id="androidHomeDownloadButton"
+                  has-icon
+                  trailing-icon
+                >
                   Download
                   <md-icon slot="icon"
                     ><span class="material-symbols-outlined"
@@ -159,13 +163,13 @@
               class="lesson-title-field"
             ></md-outlined-text-field>
             <div class="toolbar-actions">
-              <md-filled-button id="androidLessonAddBlock">
+              <md-filled-button id="androidLessonAddBlock" has-icon>
                 <md-icon slot="icon"
                   ><span class="material-symbols-outlined">add</span></md-icon
                 >
                 Add block
               </md-filled-button>
-              <md-outlined-button id="androidLessonImportButton">
+              <md-outlined-button id="androidLessonImportButton" has-icon>
                 <md-icon slot="icon"
                   ><span class="material-symbols-outlined">upload</span></md-icon
                 >
@@ -177,7 +181,7 @@
                 accept="application/json"
                 hidden
               />
-              <md-text-button id="androidLessonResetButton">
+              <md-text-button id="androidLessonResetButton" has-icon>
                 <md-icon slot="icon"
                   ><span class="material-symbols-outlined"
                     >refresh</span
@@ -219,7 +223,7 @@
                 aria-live="polite"
               ></div>
               <div class="preview-actions">
-                <md-filled-tonal-button id="androidLessonCopyButton">
+                <md-filled-tonal-button id="androidLessonCopyButton" has-icon>
                   <md-icon slot="icon"
                     ><span class="material-symbols-outlined"
                       >content_copy</span
@@ -229,6 +233,7 @@
                 </md-filled-tonal-button>
                 <md-outlined-button
                   id="androidLessonDownloadButton"
+                  has-icon
                   trailing-icon
                 >
                   Download

--- a/pages/apis/app-toolkit.html
+++ b/pages/apis/app-toolkit.html
@@ -58,13 +58,13 @@
             </li>
           </ol>
           <div class="plan-actions">
-            <md-filled-tonal-button id="appToolkitFocusButton">
+            <md-filled-tonal-button id="appToolkitFocusButton" has-icon>
               <md-icon slot="icon"
                 ><span class="material-symbols-outlined">timelapse</span></md-icon
               >
               Start focus session
             </md-filled-tonal-button>
-            <md-text-button id="appToolkitNotesButton">
+            <md-text-button id="appToolkitNotesButton" has-icon>
               <md-icon slot="icon"
                 ><span class="material-symbols-outlined">edit_note</span></md-icon
               >
@@ -131,13 +131,13 @@
   >
     <div class="builder-toolbar">
       <div class="builder-toolbar-actions">
-        <md-filled-button id="appToolkitAddApp">
+        <md-filled-button id="appToolkitAddApp" has-icon>
           <md-icon slot="icon"
             ><span class="material-symbols-outlined">add</span></md-icon
           >
           Add app
         </md-filled-button>
-        <md-outlined-button id="appToolkitImportButton">
+        <md-outlined-button id="appToolkitImportButton" has-icon>
           <md-icon slot="icon"
             ><span class="material-symbols-outlined">upload</span></md-icon
           >
@@ -149,7 +149,7 @@
           accept="application/json"
           hidden
         />
-        <md-text-button id="appToolkitResetButton">
+        <md-text-button id="appToolkitResetButton" has-icon>
           <md-icon slot="icon"
             ><span class="material-symbols-outlined">refresh</span></md-icon
           >
@@ -221,7 +221,7 @@
               ><span class="material-symbols-outlined">link</span></md-icon
             >
           </md-outlined-text-field>
-          <md-filled-tonal-button id="appToolkitFetchButton">
+          <md-filled-tonal-button id="appToolkitFetchButton" has-icon>
             <md-icon slot="icon"
               ><span class="material-symbols-outlined">cloud_download</span></md-icon
             >
@@ -231,6 +231,7 @@
         <div class="builder-remote-presets" aria-label="Quick fetch shortcuts">
           <span class="builder-remote-presets-label">Quick links</span>
           <md-text-button
+            has-icon
             data-app-toolkit-preset="https://raw.githubusercontent.com/MihaiCristianCondrea/com.d4rk.apis/refs/heads/main/App%20Toolkit/debug/en/home/api_android_apps.json"
             id="appToolkitDebugPreset"
           >
@@ -240,6 +241,7 @@
             Debug · EN
           </md-text-button>
           <md-text-button
+            has-icon
             data-app-toolkit-preset="https://raw.githubusercontent.com/MihaiCristianCondrea/com.d4rk.apis/refs/heads/main/App%20Toolkit/release/en/home/api_android_apps.json"
             id="appToolkitReleasePreset"
           >
@@ -286,7 +288,7 @@
           </ul>
         </div>
         <div class="builder-github-launch">
-          <md-filled-button id="appToolkitGithubWizardButton">
+          <md-filled-button id="appToolkitGithubWizardButton" has-icon>
             <md-icon slot="icon"
               ><span class="material-symbols-outlined">rocket_launch</span></md-icon
             >
@@ -320,13 +322,17 @@
           aria-live="polite"
         ></div>
         <div class="preview-actions">
-          <md-filled-tonal-button id="appToolkitCopyButton">
+          <md-filled-tonal-button id="appToolkitCopyButton" has-icon>
             <md-icon slot="icon"
               ><span class="material-symbols-outlined">content_copy</span></md-icon
             >
             Copy JSON
           </md-filled-tonal-button>
-          <md-outlined-button id="appToolkitDownloadButton" trailing-icon>
+          <md-outlined-button
+            id="appToolkitDownloadButton"
+            has-icon
+            trailing-icon
+          >
             Download
             <md-icon slot="icon"
               ><span class="material-symbols-outlined">download</span></md-icon
@@ -424,7 +430,7 @@
                 accept="text/plain,.txt,.token"
                 hidden
               />
-              <md-outlined-button id="appToolkitGithubTokenFileButton">
+              <md-outlined-button id="appToolkitGithubTokenFileButton" has-icon>
                 <md-icon slot="icon"
                   ><span class="material-symbols-outlined">description</span></md-icon
                 >

--- a/pages/apis/english-with-lidia.html
+++ b/pages/apis/english-with-lidia.html
@@ -55,13 +55,13 @@
           data-builder-type="english-home"
         >
           <div class="builder-toolbar">
-            <md-filled-button id="englishHomeAddCard">
+            <md-filled-button id="englishHomeAddCard" has-icon>
               <md-icon slot="icon"
                 ><span class="material-symbols-outlined">add</span></md-icon
               >
               Add card
             </md-filled-button>
-            <md-outlined-button id="englishHomeImportButton">
+            <md-outlined-button id="englishHomeImportButton" has-icon>
               <md-icon slot="icon"
                 ><span class="material-symbols-outlined">upload</span></md-icon
               >
@@ -73,7 +73,7 @@
               accept="application/json"
               hidden
             />
-            <md-text-button id="englishHomeResetButton">
+            <md-text-button id="englishHomeResetButton" has-icon>
               <md-icon slot="icon"
                 ><span class="material-symbols-outlined">refresh</span></md-icon
               >
@@ -106,7 +106,7 @@
                 aria-live="polite"
               ></div>
               <div class="preview-actions">
-                <md-filled-tonal-button id="englishHomeCopyButton">
+                <md-filled-tonal-button id="englishHomeCopyButton" has-icon>
                   <md-icon slot="icon"
                     ><span class="material-symbols-outlined"
                       >content_copy</span
@@ -114,7 +114,11 @@
                   >
                   Copy JSON
                 </md-filled-tonal-button>
-                <md-outlined-button id="englishHomeDownloadButton" trailing-icon>
+                <md-outlined-button
+                  id="englishHomeDownloadButton"
+                  has-icon
+                  trailing-icon
+                >
                   Download
                   <md-icon slot="icon"
                     ><span class="material-symbols-outlined"
@@ -160,13 +164,13 @@
               class="lesson-title-field"
             ></md-outlined-text-field>
             <div class="toolbar-actions">
-              <md-filled-button id="englishLessonAddBlock">
+              <md-filled-button id="englishLessonAddBlock" has-icon>
                 <md-icon slot="icon"
                   ><span class="material-symbols-outlined">add</span></md-icon
                 >
                 Add block
               </md-filled-button>
-              <md-outlined-button id="englishLessonImportButton">
+              <md-outlined-button id="englishLessonImportButton" has-icon>
                 <md-icon slot="icon"
                   ><span class="material-symbols-outlined">upload</span></md-icon
                 >
@@ -178,7 +182,7 @@
                 accept="application/json"
                 hidden
               />
-              <md-text-button id="englishLessonResetButton">
+              <md-text-button id="englishLessonResetButton" has-icon>
                 <md-icon slot="icon"
                   ><span class="material-symbols-outlined"
                     >refresh</span
@@ -220,7 +224,7 @@
                 aria-live="polite"
               ></div>
               <div class="preview-actions">
-                <md-filled-tonal-button id="englishLessonCopyButton">
+                <md-filled-tonal-button id="englishLessonCopyButton" has-icon>
                   <md-icon slot="icon"
                     ><span class="material-symbols-outlined"
                       >content_copy</span
@@ -230,6 +234,7 @@
                 </md-filled-tonal-button>
                 <md-outlined-button
                   id="englishLessonDownloadButton"
+                  has-icon
                   trailing-icon
                 >
                   Download

--- a/pages/drawer/about-me.html
+++ b/pages/drawer/about-me.html
@@ -77,7 +77,7 @@
 
   <div class="profile-card-actions">
     <a href="#contact">
-      <md-filled-button>
+      <md-filled-button has-icon>
         <md-icon slot="icon"
           ><span class="material-symbols-outlined">mail</span></md-icon
         >
@@ -85,7 +85,7 @@
       </md-filled-button>
     </a>
     <a href="#resume">
-      <md-filled-button>
+      <md-filled-button has-icon>
         <md-icon slot="icon"
           ><span class="material-symbols-outlined">description</span></md-icon
         >

--- a/pages/drawer/contact.html
+++ b/pages/drawer/contact.html
@@ -10,7 +10,7 @@
 
   <div class="contact-info">
     <p>I'll try to respond as soon as possible.</p>
-    <md-filled-button id="openContactDialog">
+    <md-filled-button id="openContactDialog" has-icon>
       <md-icon slot="icon"
         ><span class="material-symbols-outlined">mail</span></md-icon
       >
@@ -27,7 +27,7 @@
 
   <div class="resume-button">
     <a href="#resume">
-      <md-filled-button>
+      <md-filled-button has-icon>
         <md-icon slot="icon"
           ><span class="material-symbols-outlined">description</span></md-icon
         >


### PR DESCRIPTION
## Summary
- set Material buttons that render icons to use the documented has-icon and trailing-icon APIs
- replace the invalid tonal button usage with md-filled-tonal-button to restore correct styling

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e208a0905c832db917206b72a0b748